### PR TITLE
fix(support/collection): renamed ReadOnly to ReadOnlyCollection to av…

### DIFF
--- a/src/Support/Collection/ReadOnlyCollection.php
+++ b/src/Support/Collection/ReadOnlyCollection.php
@@ -16,9 +16,9 @@ namespace Phalcon\Support\Collection;
 use Phalcon\Support\Collection;
 
 /**
- * Phalcon\Collection\ReadOnly is a read only Collection object
+ * A read only Collection object
  */
-class ReadOnly extends Collection
+class ReadOnlyCollection extends Collection
 {
     /**
      * Delete the element from the collection

--- a/tests/unit/Support/Collection/ReadOnlyCollection/ClearCest.php
+++ b/tests/unit/Support/Collection/ReadOnlyCollection/ClearCest.php
@@ -11,24 +11,24 @@
 
 declare(strict_types=1);
 
-namespace Phalcon\Tests\Unit\Support\Collection\ReadOnly;
+namespace Phalcon\Tests\Unit\Support\Collection\ReadOnlyCollection;
 
-use Phalcon\Support\Collection\ReadOnly;
+use Phalcon\Support\Collection\ReadOnlyCollection;
 use UnitTester;
 
-class CountCest
+class ClearCest
 {
     /**
-     * Tests Phalcon\Support\Collection\ReadOnly :: count()
+     * Tests Phalcon\Support\Collection\ReadOnlyCollection :: clear()
      *
      * @param UnitTester $I
      *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
      */
-    public function supportCollectionCount(UnitTester $I)
+    public function supportCollectionClear(UnitTester $I)
     {
-        $I->wantToTest('Support\Collection\ReadOnly - count()');
+        $I->wantToTest('Support\Collection\ReadOnlyCollection - clear()');
 
         $data = [
             'one'   => 'two',
@@ -36,13 +36,15 @@ class CountCest
             'five'  => 'six',
         ];
 
-        $collection = new ReadOnly($data);
+        $collection = new ReadOnlyCollection($data);
 
-        $expected = 3;
+        $expected = $data;
         $actual   = $collection->toArray();
-        $I->assertCount($expected, $actual);
+        $I->assertEquals($expected, $actual);
 
-        $expected = 3;
+        $collection->clear();
+
+        $expected = 0;
         $actual   = $collection->count();
         $I->assertEquals($expected, $actual);
     }

--- a/tests/unit/Support/Collection/ReadOnlyCollection/ConstructCest.php
+++ b/tests/unit/Support/Collection/ReadOnlyCollection/ConstructCest.php
@@ -11,15 +11,15 @@
 
 declare(strict_types=1);
 
-namespace Phalcon\Tests\Unit\Support\Collection\ReadOnly;
+namespace Phalcon\Tests\Unit\Support\Collection\ReadOnlyCollection;
 
-use Phalcon\Support\Collection\ReadOnly;
+use Phalcon\Support\Collection\ReadOnlyCollection;
 use UnitTester;
 
 class ConstructCest
 {
     /**
-     * Tests Phalcon\Support\Collection\ReadOnly :: __construct()
+     * Tests Phalcon\Support\Collection\ReadOnlyCollection :: __construct()
      *
      * @param UnitTester $I
      *
@@ -28,10 +28,10 @@ class ConstructCest
      */
     public function supportCollectionConstruct(UnitTester $I)
     {
-        $I->wantToTest('Support\Collection\ReadOnly - __construct()');
-        $collection = new ReadOnly();
+        $I->wantToTest('Support\Collection\ReadOnlyCollection - __construct()');
+        $collection = new ReadOnlyCollection();
 
-        $class = ReadOnly::class;
+        $class = ReadOnlyCollection::class;
         $I->assertInstanceOf($class, $collection);
     }
 }

--- a/tests/unit/Support/Collection/ReadOnlyCollection/CountCest.php
+++ b/tests/unit/Support/Collection/ReadOnlyCollection/CountCest.php
@@ -11,24 +11,24 @@
 
 declare(strict_types=1);
 
-namespace Phalcon\Tests\Unit\Support\Collection\ReadOnly;
+namespace Phalcon\Tests\Unit\Support\Collection\ReadOnlyCollectionCollection;
 
-use Phalcon\Support\Collection\ReadOnly;
+use Phalcon\Support\Collection\ReadOnlyCollection;
 use UnitTester;
 
-class InitCest
+class CountCest
 {
     /**
-     * Tests Phalcon\Support\Collection\ReadOnly :: init()
+     * Tests Phalcon\Support\Collection\ReadOnlyCollection :: count()
      *
      * @param UnitTester $I
      *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
      */
-    public function supportCollectionInit(UnitTester $I)
+    public function supportCollectionCount(UnitTester $I)
     {
-        $I->wantToTest('Support\Collection\ReadOnly - init()');
+        $I->wantToTest('Support\Collection\ReadOnlyCollection - count()');
 
         $data = [
             'one'   => 'two',
@@ -36,16 +36,14 @@ class InitCest
             'five'  => 'six',
         ];
 
-        $collection = new ReadOnly();
+        $collection = new ReadOnlyCollection($data);
 
-        $expected = 0;
-        $actual   = $collection->count();
-        $I->assertEquals($expected, $actual);
-
-        $collection->init($data);
-
-        $expected = $data;
+        $expected = 3;
         $actual   = $collection->toArray();
+        $I->assertCount($expected, $actual);
+
+        $expected = 3;
+        $actual   = $collection->count();
         $I->assertEquals($expected, $actual);
     }
 }

--- a/tests/unit/Support/Collection/ReadOnlyCollection/GetCest.php
+++ b/tests/unit/Support/Collection/ReadOnlyCollection/GetCest.php
@@ -11,17 +11,17 @@
 
 declare(strict_types=1);
 
-namespace Phalcon\Tests\Unit\Support\Collection\ReadOnly;
+namespace Phalcon\Tests\Unit\Support\Collection\ReadOnlyCollectionCollection;
 
 use Codeception\Example;
-use Phalcon\Support\Collection\ReadOnly;
+use Phalcon\Support\Collection\ReadOnlyCollection;
 use stdClass;
 use UnitTester;
 
 class GetCest
 {
     /**
-     * Tests Phalcon\Support\Collection\ReadOnly :: get()
+     * Tests Phalcon\Support\Collection\ReadOnlyCollection :: get()
      *
      * @param UnitTester $I
      *
@@ -30,7 +30,7 @@ class GetCest
      */
     public function supportCollectionGet(UnitTester $I)
     {
-        $I->wantToTest('Support\Collection\ReadOnly - get()');
+        $I->wantToTest('Support\Collection\ReadOnlyCollection - get()');
 
         $data = [
             'one'   => 'two',
@@ -38,7 +38,7 @@ class GetCest
             'five'  => 'six',
         ];
 
-        $collection = new ReadOnly($data);
+        $collection = new ReadOnlyCollection($data);
         $expected   = 'four';
 
         $actual = $collection->get('three');
@@ -70,9 +70,9 @@ class GetCest
      */
     public function helperArrGetCast(UnitTester $I, Example $example)
     {
-        $I->wantToTest('Support\Collection\ReadOnly - get() - cast ' . $example[0]);
+        $I->wantToTest('Support\Collection\ReadOnlyCollection - get() - cast ' . $example[0]);
 
-        $collection = new ReadOnly(
+        $collection = new ReadOnlyCollection(
             [
                 'value' => $example[1],
             ]

--- a/tests/unit/Support/Collection/ReadOnlyCollection/GetIteratorCest.php
+++ b/tests/unit/Support/Collection/ReadOnlyCollection/GetIteratorCest.php
@@ -11,15 +11,15 @@
 
 declare(strict_types=1);
 
-namespace Phalcon\Tests\Unit\Support\Collection\ReadOnly;
+namespace Phalcon\Tests\Unit\Support\Collection\ReadOnlyCollectionCollection;
 
-use Phalcon\Support\Collection\ReadOnly;
+use Phalcon\Support\Collection\ReadOnlyCollection;
 use UnitTester;
 
 class GetIteratorCest
 {
     /**
-     * Tests Phalcon\Support\Collection\ReadOnly :: getIterator()
+     * Tests Phalcon\Support\Collection\ReadOnlyCollection :: getIterator()
      *
      * @param UnitTester $I
      *
@@ -28,7 +28,7 @@ class GetIteratorCest
      */
     public function supportCollectionGetIterator(UnitTester $I)
     {
-        $I->wantToTest('Support\Collection\ReadOnly - getIterator()');
+        $I->wantToTest('Support\Collection\ReadOnlyCollection - getIterator()');
 
         $data = [
             'one'   => 'two',
@@ -36,7 +36,7 @@ class GetIteratorCest
             'five'  => 'six',
         ];
 
-        $collection = new ReadOnly($data);
+        $collection = new ReadOnlyCollection($data);
 
         foreach ($collection as $key => $value) {
             $expected = $data[$key];

--- a/tests/unit/Support/Collection/ReadOnlyCollection/GetKeysCest.php
+++ b/tests/unit/Support/Collection/ReadOnlyCollection/GetKeysCest.php
@@ -11,24 +11,24 @@
 
 declare(strict_types=1);
 
-namespace Phalcon\Tests\Unit\Support\Collection\ReadOnly;
+namespace Phalcon\Tests\Unit\Support\Collection\ReadOnlyCollection;
 
-use Phalcon\Support\Collection\ReadOnly;
+use Phalcon\Support\Collection\ReadOnlyCollection;
 use UnitTester;
 
 class GetKeysCest
 {
     /**
-     * Tests Phalcon\Support\Collection\ReadOnly :: get()
+     * Tests Phalcon\Support\Collection\ReadOnlyCollection :: get()
      *
      * @param UnitTester $I
      *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
      */
-    public function supportCollectionReadOnlyGetKeys(UnitTester $I)
+    public function supportCollectionReadOnlyCollectionGetKeys(UnitTester $I)
     {
-        $I->wantToTest('Support\Collection\ReadOnly - getKeys()');
+        $I->wantToTest('Support\Collection\ReadOnlyCollection - getKeys()');
 
         $keys = [
             'one',
@@ -42,7 +42,7 @@ class GetKeysCest
             'five'  => 'six',
         ];
 
-        $collection = new ReadOnly($data);
+        $collection = new ReadOnlyCollection($data);
 
         $expected = $keys;
         $actual   = $collection->getKeys();
@@ -54,7 +54,7 @@ class GetKeysCest
             'five'  => 'six',
         ];
 
-        $collection = new ReadOnly($data);
+        $collection = new ReadOnlyCollection($data);
         $expected   = $keys;
         $actual     = $collection->getKeys();
         $I->assertEquals($expected, $actual);

--- a/tests/unit/Support/Collection/ReadOnlyCollection/GetValuesCest.php
+++ b/tests/unit/Support/Collection/ReadOnlyCollection/GetValuesCest.php
@@ -11,24 +11,24 @@
 
 declare(strict_types=1);
 
-namespace Phalcon\Tests\Unit\Support\Collection\ReadOnly;
+namespace Phalcon\Tests\Unit\Support\Collection\ReadOnlyCollection;
 
-use Phalcon\Support\Collection\ReadOnly;
+use Phalcon\Support\Collection\ReadOnlyCollection;
 use UnitTester;
 
 class GetValuesCest
 {
     /**
-     * Tests Phalcon\Support\Collection\ReadOnly :: get()
+     * Tests Phalcon\Support\Collection\ReadOnlyCollection :: get()
      *
      * @param UnitTester $I
      *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
      */
-    public function supportCollectionReadOnlyGetValues(UnitTester $I)
+    public function supportCollectionReadOnlyCollectionGetValues(UnitTester $I)
     {
-        $I->wantToTest('Support\Collection\ReadOnly - getValues()');
+        $I->wantToTest('Support\Collection\ReadOnlyCollection - getValues()');
 
         $data = [
             'one'   => 'two',
@@ -36,7 +36,7 @@ class GetValuesCest
             'five'  => 'six',
         ];
 
-        $collection = new ReadOnly($data);
+        $collection = new ReadOnlyCollection($data);
 
         $expected = [
             'two',

--- a/tests/unit/Support/Collection/ReadOnlyCollection/HasCest.php
+++ b/tests/unit/Support/Collection/ReadOnlyCollection/HasCest.php
@@ -11,15 +11,15 @@
 
 declare(strict_types=1);
 
-namespace Phalcon\Tests\Unit\Support\Collection\ReadOnly;
+namespace Phalcon\Tests\Unit\Support\Collection\ReadOnlyCollection;
 
-use Phalcon\Support\Collection\ReadOnly;
+use Phalcon\Support\Collection\ReadOnlyCollection;
 use UnitTester;
 
 class HasCest
 {
     /**
-     * Tests Phalcon\Support\Collection\ReadOnly :: has()
+     * Tests Phalcon\Support\Collection\ReadOnlyCollection :: has()
      *
      * @param UnitTester $I
      *
@@ -36,7 +36,7 @@ class HasCest
             'five'  => 'six',
         ];
 
-        $collection = new ReadOnly($data);
+        $collection = new ReadOnlyCollection($data);
 
         $actual = $collection->has('three');
         $I->assertTrue($actual);
@@ -64,7 +64,7 @@ class HasCest
     }
 
     /**
-     * Tests Phalcon\Support\Collection\ReadOnly :: has() - sensitive
+     * Tests Phalcon\Support\Collection\ReadOnlyCollection :: has() - sensitive
      *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
@@ -79,7 +79,7 @@ class HasCest
             'five'  => 'six',
         ];
 
-        $collection = new ReadOnly($data, false);
+        $collection = new ReadOnlyCollection($data, false);
 
         $actual = $collection->has('three');
         $I->assertTrue($actual);

--- a/tests/unit/Support/Collection/ReadOnlyCollection/InitCest.php
+++ b/tests/unit/Support/Collection/ReadOnlyCollection/InitCest.php
@@ -11,24 +11,24 @@
 
 declare(strict_types=1);
 
-namespace Phalcon\Tests\Unit\Support\Collection\ReadOnly;
+namespace Phalcon\Tests\Unit\Support\Collection\ReadOnlyCollection;
 
-use Phalcon\Support\Collection\ReadOnly;
+use Phalcon\Support\Collection\ReadOnlyCollection;
 use UnitTester;
 
-class UnserializeCest
+class InitCest
 {
     /**
-     * Tests Phalcon\Support\Collection\ReadOnly :: serialize()
+     * Tests Phalcon\Support\Collection\ReadOnlyCollection :: init()
      *
      * @param UnitTester $I
      *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
      */
-    public function supportCollectionSerialize(UnitTester $I)
+    public function supportCollectionInit(UnitTester $I)
     {
-        $I->wantToTest('Support\Collection\ReadOnly - serialize()');
+        $I->wantToTest('Support\Collection\ReadOnlyCollection - init()');
 
         $data = [
             'one'   => 'two',
@@ -36,10 +36,13 @@ class UnserializeCest
             'five'  => 'six',
         ];
 
-        $serialized = serialize($data);
-        $collection = new ReadOnly();
+        $collection = new ReadOnlyCollection();
 
-        $collection->unserialize($serialized);
+        $expected = 0;
+        $actual   = $collection->count();
+        $I->assertEquals($expected, $actual);
+
+        $collection->init($data);
 
         $expected = $data;
         $actual   = $collection->toArray();

--- a/tests/unit/Support/Collection/ReadOnlyCollection/JsonSerializeCest.php
+++ b/tests/unit/Support/Collection/ReadOnlyCollection/JsonSerializeCest.php
@@ -11,16 +11,16 @@
 
 declare(strict_types=1);
 
-namespace Phalcon\Tests\Unit\Support\Collection\ReadOnly;
+namespace Phalcon\Tests\Unit\Support\Collection\ReadOnlyCollection;
 
-use Phalcon\Support\Collection\ReadOnly;
+use Phalcon\Support\Collection\ReadOnlyCollection;
 use Phalcon\Tests\Fixtures\JsonFixture;
 use UnitTester;
 
 class JsonSerializeCest
 {
     /**
-     * Tests Phalcon\Support\Collection\ReadOnly :: jsonSerialize()
+     * Tests Phalcon\Support\Collection\ReadOnlyCollection :: jsonSerialize()
      *
      * @param UnitTester $I
      *
@@ -29,7 +29,7 @@ class JsonSerializeCest
      */
     public function supportCollectionJsonSerialize(UnitTester $I)
     {
-        $I->wantToTest('Support\Collection\ReadOnly - jsonSerialize()');
+        $I->wantToTest('Support\Collection\ReadOnlyCollection - jsonSerialize()');
 
         $data = [
             'one'   => 'two',
@@ -37,7 +37,7 @@ class JsonSerializeCest
             'five'  => 'six',
         ];
 
-        $collection = new ReadOnly($data);
+        $collection = new ReadOnlyCollection($data);
 
         $expected = $data;
         $actual   = $collection->jsonSerialize();
@@ -59,7 +59,7 @@ class JsonSerializeCest
             ],
         ];
 
-        $collection = new ReadOnly($data);
+        $collection = new ReadOnlyCollection($data);
 
         $actual = $collection->jsonSerialize();
         $I->assertEquals($expected, $actual);

--- a/tests/unit/Support/Collection/ReadOnlyCollection/RemoveCest.php
+++ b/tests/unit/Support/Collection/ReadOnlyCollection/RemoveCest.php
@@ -11,16 +11,16 @@
 
 declare(strict_types=1);
 
-namespace Phalcon\Tests\Unit\Support\Collection\ReadOnly;
+namespace Phalcon\Tests\Unit\Support\Collection\ReadOnlyCollection;
 
 use Phalcon\Support\Collection\Exception;
-use Phalcon\Support\Collection\ReadOnly;
+use Phalcon\Support\Collection\ReadOnlyCollection;
 use UnitTester;
 
 class RemoveCest
 {
     /**
-     * Tests Phalcon\Support\Collection\ReadOnly :: remove()
+     * Tests Phalcon\Support\Collection\ReadOnlyCollection :: remove()
      *
      * @param UnitTester $I
      *
@@ -29,14 +29,14 @@ class RemoveCest
      */
     public function supportCollectionRemove(UnitTester $I)
     {
-        $I->wantToTest('Support\Collection\ReadOnly - remove()');
+        $I->wantToTest('Support\Collection\ReadOnlyCollection - remove()');
 
         $data       = [
             'one'   => 'two',
             'three' => 'four',
             'five'  => 'six',
         ];
-        $collection = new ReadOnly($data);
+        $collection = new ReadOnlyCollection($data);
 
         $I->expectThrowable(
             new Exception('The object is read only'),

--- a/tests/unit/Support/Collection/ReadOnlyCollection/SerializeCest.php
+++ b/tests/unit/Support/Collection/ReadOnlyCollection/SerializeCest.php
@@ -11,24 +11,24 @@
 
 declare(strict_types=1);
 
-namespace Phalcon\Tests\Unit\Support\Collection\ReadOnly;
+namespace Phalcon\Tests\Unit\Support\Collection\ReadOnlyCollection;
 
-use Phalcon\Support\Collection\ReadOnly;
+use Phalcon\Support\Collection\ReadOnlyCollection;
 use UnitTester;
 
-class ToArrayCest
+class SerializeCest
 {
     /**
-     * Tests Phalcon\Support\Collection\ReadOnly :: toArray()
+     * Tests Phalcon\Support\Collection\ReadOnlyCollection :: serialize()
      *
      * @param UnitTester $I
      *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
      */
-    public function supportCollectionToArray(UnitTester $I)
+    public function supportCollectionSerialize(UnitTester $I)
     {
-        $I->wantToTest('Support\Collection\ReadOnly - toArray()');
+        $I->wantToTest('Support\Collection\ReadOnlyCollection - serialize()');
 
         $data = [
             'one'   => 'two',
@@ -36,10 +36,10 @@ class ToArrayCest
             'five'  => 'six',
         ];
 
-        $collection = new ReadOnly($data);
+        $collection = new ReadOnlyCollection($data);
 
-        $expected = $data;
-        $actual   = $collection->toArray();
+        $expected = serialize($data);
+        $actual   = $collection->serialize();
         $I->assertEquals($expected, $actual);
     }
 }

--- a/tests/unit/Support/Collection/ReadOnlyCollection/SetCest.php
+++ b/tests/unit/Support/Collection/ReadOnlyCollection/SetCest.php
@@ -11,16 +11,16 @@
 
 declare(strict_types=1);
 
-namespace Phalcon\Tests\Unit\Support\Collection\ReadOnly;
+namespace Phalcon\Tests\Unit\Support\Collection\ReadOnlyCollection;
 
 use Phalcon\Support\Collection\Exception;
-use Phalcon\Support\Collection\ReadOnly;
+use Phalcon\Support\Collection\ReadOnlyCollection;
 use UnitTester;
 
 class SetCest
 {
     /**
-     * Tests Phalcon\Support\Collection\ReadOnly :: set()
+     * Tests Phalcon\Support\Collection\ReadOnlyCollection :: set()
      *
      * @param UnitTester $I
      *
@@ -29,12 +29,12 @@ class SetCest
      */
     public function supportCollectionSet(UnitTester $I)
     {
-        $I->wantToTest('Support\Collection\ReadOnly - set()');
+        $I->wantToTest('Support\Collection\ReadOnlyCollection - set()');
 
         $I->expectThrowable(
             new Exception('The object is read only'),
             function () {
-                $collection = new ReadOnly();
+                $collection = new ReadOnlyCollection();
                 $collection->set('three', 123);
             }
         );
@@ -42,7 +42,7 @@ class SetCest
         $I->expectThrowable(
             new Exception('The object is read only'),
             function () {
-                $collection        = new ReadOnly();
+                $collection        = new ReadOnlyCollection();
                 $collection->three = 'Phalcon';
             }
         );
@@ -50,7 +50,7 @@ class SetCest
         $I->expectThrowable(
             new Exception('The object is read only'),
             function () {
-                $collection = new ReadOnly();
+                $collection = new ReadOnlyCollection();
                 $collection->offsetSet('three', 123);
             }
         );
@@ -58,7 +58,7 @@ class SetCest
         $I->expectThrowable(
             new Exception('The object is read only'),
             function () {
-                $collection          = new ReadOnly();
+                $collection          = new ReadOnlyCollection();
                 $collection['three'] = true;
             }
         );

--- a/tests/unit/Support/Collection/ReadOnlyCollection/ToArrayCest.php
+++ b/tests/unit/Support/Collection/ReadOnlyCollection/ToArrayCest.php
@@ -11,24 +11,24 @@
 
 declare(strict_types=1);
 
-namespace Phalcon\Tests\Unit\Support\Collection\ReadOnly;
+namespace Phalcon\Tests\Unit\Support\Collection\ReadOnlyCollection;
 
-use Phalcon\Support\Collection\ReadOnly;
+use Phalcon\Support\Collection\ReadOnlyCollection;
 use UnitTester;
 
-class SerializeCest
+class ToArrayCest
 {
     /**
-     * Tests Phalcon\Support\Collection\ReadOnly :: serialize()
+     * Tests Phalcon\Support\Collection\ReadOnlyCollection :: toArray()
      *
      * @param UnitTester $I
      *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
      */
-    public function supportCollectionSerialize(UnitTester $I)
+    public function supportCollectionToArray(UnitTester $I)
     {
-        $I->wantToTest('Support\Collection\ReadOnly - serialize()');
+        $I->wantToTest('Support\Collection\ReadOnlyCollection - toArray()');
 
         $data = [
             'one'   => 'two',
@@ -36,10 +36,10 @@ class SerializeCest
             'five'  => 'six',
         ];
 
-        $collection = new ReadOnly($data);
+        $collection = new ReadOnlyCollection($data);
 
-        $expected = serialize($data);
-        $actual   = $collection->serialize();
+        $expected = $data;
+        $actual   = $collection->toArray();
         $I->assertEquals($expected, $actual);
     }
 }

--- a/tests/unit/Support/Collection/ReadOnlyCollection/ToJsonCest.php
+++ b/tests/unit/Support/Collection/ReadOnlyCollection/ToJsonCest.php
@@ -11,15 +11,15 @@
 
 declare(strict_types=1);
 
-namespace Phalcon\Tests\Unit\Support\Collection\ReadOnly;
+namespace Phalcon\Tests\Unit\Support\Collection\ReadOnlyCollection;
 
-use Phalcon\Support\Collection\ReadOnly;
+use Phalcon\Support\Collection\ReadOnlyCollection;
 use UnitTester;
 
 class ToJsonCest
 {
     /**
-     * Tests Phalcon\Support\Collection\ReadOnly :: toJson()
+     * Tests Phalcon\Support\Collection\ReadOnlyCollection :: toJson()
      *
      * @param UnitTester $I
      *
@@ -28,7 +28,7 @@ class ToJsonCest
      */
     public function supportCollectionToJson(UnitTester $I)
     {
-        $I->wantToTest('Support\Collection\ReadOnly - toJson()');
+        $I->wantToTest('Support\Collection\ReadOnlyCollection - toJson()');
 
         $data = [
             'one'   => 'two',
@@ -36,7 +36,7 @@ class ToJsonCest
             'five'  => 'six',
         ];
 
-        $collection = new ReadOnly($data);
+        $collection = new ReadOnlyCollection($data);
 
         $expected = json_encode($data);
         $actual   = $collection->toJson();

--- a/tests/unit/Support/Collection/ReadOnlyCollection/UnserializeCest.php
+++ b/tests/unit/Support/Collection/ReadOnlyCollection/UnserializeCest.php
@@ -11,24 +11,24 @@
 
 declare(strict_types=1);
 
-namespace Phalcon\Tests\Unit\Support\Collection\ReadOnly;
+namespace Phalcon\Tests\Unit\Support\Collection\ReadOnlyCollection;
 
-use Phalcon\Support\Collection\ReadOnly;
+use Phalcon\Support\Collection\ReadOnlyCollection;
 use UnitTester;
 
-class ClearCest
+class UnserializeCest
 {
     /**
-     * Tests Phalcon\Support\Collection\ReadOnly :: clear()
+     * Tests Phalcon\Support\Collection\ReadOnlyCollection :: serialize()
      *
      * @param UnitTester $I
      *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
      */
-    public function supportCollectionClear(UnitTester $I)
+    public function supportCollectionSerialize(UnitTester $I)
     {
-        $I->wantToTest('Support\Collection\ReadOnly - clear()');
+        $I->wantToTest('Support\Collection\ReadOnlyCollection - serialize()');
 
         $data = [
             'one'   => 'two',
@@ -36,16 +36,13 @@ class ClearCest
             'five'  => 'six',
         ];
 
-        $collection = new ReadOnly($data);
+        $serialized = serialize($data);
+        $collection = new ReadOnlyCollection();
+
+        $collection->unserialize($serialized);
 
         $expected = $data;
         $actual   = $collection->toArray();
-        $I->assertEquals($expected, $actual);
-
-        $collection->clear();
-
-        $expected = 0;
-        $actual   = $collection->count();
         $I->assertEquals($expected, $actual);
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/phalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Renamed `Phalcon\Support\Collection\ReadOnly` to `Phalcon\Support\Collection\ReadOnlyCollection` to avoid conflicts with the read-only feature in PHP 8.1

Thanks
