### PR TITLE
Add Redis serializer json constant

### DIFF
--- a/src/Storage/Adapter/Redis.php
+++ b/src/Storage/Adapter/Redis.php
@@ -368,6 +368,10 @@ class Redis extends AbstractAdapter
             $map['msgpack'] = constant('\\Redis::SERIALIZER_MSGPACK');
         }
 
+        if (defined('\\Redis::SERIALIZER_JSON')) {
+            $map['json'] = constant('\\Redis::SERIALIZER_JSON');
+        }
+
         $serializer = mb_strtolower($this->defaultSerializer);
 
         if (true === isset($map[$serializer])) {


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/phalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
Add the Redis serializer json constant, Added in phpredis v5.0.0:
https://github.com/phpredis/phpredis/blob/develop/Changelog.md#500---2019-07-02-github-pecl

Thanks
