### PR TITLE
Make `Route:$hostname` property nullable

### DIFF
--- a/src/Mvc/Router/Route.php
+++ b/src/Mvc/Router/Route.php
@@ -57,7 +57,7 @@ class Route implements RouteInterface
     /**
      * @var string|null
      */
-    protected string $hostname = "";
+    protected ?string $hostname = null;
 
     /**
      * @var array|string


### PR DESCRIPTION
Hello!

*  Type: bug fix
*  Link to issue:

**In raising this pull request, I confirm the following:**

-  [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/phalcon/blob/master/CONTRIBUTING.md)
-  [x] I have checked that another pull request for this purpose does not exist
-  [ ] I wrote some tests for this PR
-  [ ] I have updated the relevant CHANGELOG
-  [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

Thanks
