### PR TITLE
add missing PDO FETCH constants

### DIFF
--- a/src/Db/Enum.php
+++ b/src/Db/Enum.php
@@ -35,7 +35,12 @@ class Enum
     public const FETCH_NAMED      = PDO::FETCH_NAMED;
     public const FETCH_NUM        = PDO::FETCH_NUM;
     public const FETCH_OBJ        = PDO::FETCH_OBJ;
+    public const FETCH_ORI_ABS    = PDO::FETCH_ORI_ABS;
+    public const FETCH_ORI_FIRST  = PDO::FETCH_ORI_FIRST;
+    public const FETCH_ORI_LAST   = PDO::FETCH_ORI_LAST;
     public const FETCH_ORI_NEXT   = PDO::FETCH_ORI_NEXT;
+    public const FETCH_ORI_PRIOR  = PDO::FETCH_ORI_PRIOR;
+    public const FETCH_ORI_REL    = PDO::FETCH_ORI_REL;
     public const FETCH_PROPS_LATE = PDO::FETCH_PROPS_LATE;
     public const FETCH_SERIALIZE  = PDO::FETCH_SERIALIZE;
     public const FETCH_UNIQUE     = PDO::FETCH_UNIQUE;


### PR DESCRIPTION
Hello!

*  Type: bug fix | new feature | code quality | documentation
*  Link to issue:

**In raising this pull request, I confirm the following:**

-  [x ] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/phalcon/blob/master/CONTRIBUTING.md)
-  [x] I have checked that another pull request for this purpose does not exist
-  [ ] I wrote some tests for this PR
-  [ ] I have updated the relevant CHANGELOG
-  [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

Add the missing PDO FETCH_* constants

Thanks
