### PR TITLE
Fix passing null of type string is deprecated warning.

### DIFF
--- a/src/Http/Cookie.php
+++ b/src/Http/Cookie.php
@@ -533,7 +533,7 @@ class Cookie extends AbstractInjectionAware implements
      * @throws CookieException
      * @see \Phalcon\Encryption\Security\Random
      */
-    public function setSignKey(string $signKey = null): CookieInterface
+    public function setSignKey(?string $signKey = null): CookieInterface
     {
         if (null !== $signKey) {
             $this->assertSignKeyIsLongEnough($signKey);

--- a/src/Http/Response/Cookies.php
+++ b/src/Http/Response/Cookies.php
@@ -265,9 +265,9 @@ class Cookies extends AbstractInjectionAware implements CookiesInterface
         mixed $value = null,
         int $expire = 0,
         string $path = '/',
-        bool $secure = null,
-        string $domain = null,
-        bool $httpOnly = null,
+        bool $secure = false,
+        string $domain = '',
+        bool $httpOnly = false,
         array $options = []
     ): CookiesInterface {
         /**
@@ -355,7 +355,7 @@ class Cookies extends AbstractInjectionAware implements CookiesInterface
      * @return CookiesInterface
      * @see \Phalcon\Encryption\Security\Random
      */
-    public function setSignKey(string $signKey = null): CookiesInterface
+    public function setSignKey(?string $signKey = null): CookiesInterface
     {
         $this->signKey = $signKey;
 


### PR DESCRIPTION
Hello!

*  Type: bug fix
*  Link to issue: https://github.com/phalcon/cphalcon/issues/16649

**In raising this pull request, I confirm the following:**

-  [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/phalcon/blob/master/CONTRIBUTING.md)
-  [x] I have checked that another pull request for this purpose does not exist
-  [ ] I wrote some tests for this PR
-  [ ] I have updated the relevant CHANGELOG
-  [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
Ensure null type deprecation and warnings are avoided, as well as follow the CookieInterface class set() method assignment default values.

Thanks
