### PR TITLE
Add remove behavior method to model manager

### DIFF
--- a/src/Mvc/Model/Manager.php
+++ b/src/Mvc/Model/Manager.php
@@ -265,6 +265,30 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
     }
 
     /**
+     * Removes a behavior from a model
+     *
+     * @param ModelInterface $model
+     * @param string         $behaviorClass
+     */
+    public function removeBehavior(
+        ModelInterface $model,
+        string $behaviorClass
+    ): void {
+        $entityName = mb_strtolower(get_class($model));
+
+        if (isset($this->behaviors[$entityName])) {
+            foreach ($this->behaviors[$entityName] as $key => $behavior) {
+                if (get_class($behavior) === $behaviorClass) {
+                    unset($this->behaviors[$entityName][$key]);
+                }
+            }
+
+            // Reindex the array to remove gaps
+            $this->behaviors[$entityName] = array_values($this->behaviors[$entityName]);
+        }
+    }
+
+    /**
      * Setup a relation reverse many to one between two models
      *
      * @param ModelInterface $model

--- a/src/Mvc/Model/ManagerInterface.php
+++ b/src/Mvc/Model/ManagerInterface.php
@@ -38,6 +38,19 @@ interface ManagerInterface
     ): void;
 
     /**
+     * Removes a behavior from a model
+     *
+     * @param ModelInterface $model
+     * @param string         $behaviorClass
+     *
+     * @return void
+     */
+    public function removeBehavior(
+        ModelInterface $model,
+        string $behaviorClass
+    ): void;
+
+    /**
      * Setup a relation reverse 1-1  between two models
      *
      * @param ModelInterface $model

--- a/tests/database/Mvc/Model/Behavior/SoftDeleteTest.php
+++ b/tests/database/Mvc/Model/Behavior/SoftDeleteTest.php
@@ -105,4 +105,36 @@ final class SoftDeleteTest extends AbstractDatabaseTestCase
         /** Check that SoftDelete wasn't working because beforeDelete event return false */
         $this->assertEquals(Invoices::STATUS_PAID, $invoice->inv_status_flag);
     }
+
+    /**
+     * Tests Phalcon\Mvc\Model\Behavior :: removeBehavior()
+     *
+     * @group  common
+     */
+    public function testMvcModelBehaviorRemoveBehavior(): void
+    {
+        /** Add row to SoftDelete then */
+        $title = uniqid('inv-');
+        $date  = date('Y-m-d H:i:s');
+        $data  = [
+            'inv_cst_id'      => 2,
+            'inv_status_flag' => Invoices::STATUS_PAID,
+            'inv_title'       => $title,
+            'inv_total'       => 100.12,
+            'inv_created_at'  => $date,
+        ];
+
+        $invoice = new InvoicesBehavior();
+        $invoice->assign($data);
+
+        // Remove the SoftDelete behavior
+        $modelsManager = $invoice->getModelsManager();
+        $modelsManager->removeBehavior($invoice, \Phalcon\Mvc\Model\Behavior\SoftDelete::class);
+
+        /* delete invoice */
+        $invoice->delete();
+
+        // Check that the SoftDelete behavior was removed and the invoice was actually deleted
+        $this->assertFalse($invoice->hasSnapshotData());
+    }
 }


### PR DESCRIPTION
Related to #277

Add functionality to remove a behavior from a model.

* Add `removeBehavior` method to `src/Mvc/Model/Manager.php` to allow removing behaviors from models.
* Implement `removeBehavior` method to take a model and a behavior class name as parameters and remove the specified behavior from the model's behaviors array.
* Update `src/Mvc/Model/ManagerInterface.php` to include the `removeBehavior` method in the interface definition.
* Add a test in `tests/database/Mvc/Model/Behavior/SoftDeleteTest.php` to cover the new functionality of removing a behavior.

