### PR TITLE
Fix argument mismatch in PHP8 in set_error_handler() for v6

### DIFF
--- a/src/Support/Debug.php
+++ b/src/Support/Debug.php
@@ -282,8 +282,7 @@ class Debug
         int $severity,
         string $message,
         string $file,
-        int $line,
-        array $context = []
+        int $line
     ): void {
         if (error_reporting() & $severity) {
             throw new ErrorException($message, 0, $severity, $file, $line);


### PR DESCRIPTION
Hello!

*  Type: bug fix | new feature | code quality | documentation
*  Link to issue: https://github.com/phalcon/cphalcon/issues/16686

**In raising this pull request, I confirm the following:**

-  [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/phalcon/blob/master/CONTRIBUTING.md)
-  [x] I have checked that another pull request for this purpose does not exist
-  [ ] I wrote some tests for this PR
-  [ ] I have updated the relevant CHANGELOG
-  [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
Ported fix from cphalcon.
PHP v7.2.0 deprecated errcontext in set_error_handler() and has been removed since php v8.0.0. The callback no longer passes errcontext, leading to the method definition of onUncaughtLowSeverity(severity, message, file, line, context) in Phalcon\Support\Debug to no longer be valid. The fix removes the unused deprecated argument.

Thanks
