### PR TITLE
T16713 gc iterable

### DIFF
--- a/src/Session/Adapter/Stream.php
+++ b/src/Session/Adapter/Stream.php
@@ -18,6 +18,9 @@ use Phalcon\Traits\Php\FileTrait;
 use Phalcon\Traits\Php\InfoTrait;
 use Phalcon\Traits\Php\IniTrait;
 
+use function error_clear_last;
+use function error_get_last;
+use function error_reporting;
 use function file_exists;
 use function rtrim;
 
@@ -133,7 +136,12 @@ class Stream extends Noop
     {
         $pattern = $this->path . $this->prefix . "*";
         $time    = time() - $max_lifetime;
-        $glob    = glob($pattern);
+        $glob    = $this->getGlobFiles($pattern);
+
+        if (false === $glob) {
+            $last = error_get_last();
+            throw new Exception($last['message'] ?? 'Unexpected gc error');
+        }
 
         if (!empty($glob)) {
             foreach ($glob as $file) {
@@ -215,5 +223,22 @@ class Stream extends Noop
         $name = (string)$name;
 
         return $this->prefix . $name;
+    }
+
+    /**
+     * Gets the glob array or returns false on failure
+     *
+     * @param string $pattern
+     *
+     * @return array|false
+     */
+    protected function getGlobFiles(string $pattern): array | false
+    {
+        $errorLevel = error_reporting(0);
+        error_clear_last();
+        $glob = glob($pattern);
+        error_reporting($errorLevel);
+
+        return $glob;
     }
 }

--- a/src/Session/Adapter/Stream.php
+++ b/src/Session/Adapter/Stream.php
@@ -136,7 +136,7 @@ class Stream extends Noop
         $glob    = glob($pattern);
 
         if (!empty($glob)) {
-            foreach (glob($pattern) as $file) {
+            foreach ($glob as $file) {
                 if (
                     file_exists($file) &&
                     is_file($file) &&

--- a/src/Session/Adapter/Stream.php
+++ b/src/Session/Adapter/Stream.php
@@ -133,14 +133,17 @@ class Stream extends Noop
     {
         $pattern = $this->path . $this->prefix . "*";
         $time    = time() - $max_lifetime;
+        $glob    = glob($pattern);
 
-        foreach (glob($pattern) as $file) {
-            if (
-                file_exists($file) &&
-                is_file($file) &&
-                filemtime($file) < $time
-            ) {
-                unlink($file);
+        if (!empty($glob)) {
+            foreach (glob($pattern) as $file) {
+                if (
+                    file_exists($file) &&
+                    is_file($file) &&
+                    filemtime($file) < $time
+                ) {
+                    unlink($file);
+                }
             }
         }
 

--- a/src/Session/Adapter/Stream.php
+++ b/src/Session/Adapter/Stream.php
@@ -131,6 +131,7 @@ class Stream extends Noop
      * @param int $max_lifetime
      *
      * @return false|int
+     * @throws Exception
      */
     public function gc(int $max_lifetime): false | int
     {
@@ -212,20 +213,6 @@ class Stream extends Noop
     }
 
     /**
-     * Helper method to get the name prefixed
-     *
-     * @param mixed $name
-     *
-     * @return string
-     */
-    protected function getPrefixedName($name): string
-    {
-        $name = (string)$name;
-
-        return $this->prefix . $name;
-    }
-
-    /**
      * Gets the glob array or returns false on failure
      *
      * @param string $pattern
@@ -240,5 +227,19 @@ class Stream extends Noop
         error_reporting($errorLevel);
 
         return $glob;
+    }
+
+    /**
+     * Helper method to get the name prefixed
+     *
+     * @param mixed $name
+     *
+     * @return string
+     */
+    protected function getPrefixedName($name): string
+    {
+        $name = (string)$name;
+
+        return $this->prefix . $name;
     }
 }

--- a/tests/_data/fixtures/Session/Adapter/StreamGlobFixture.php
+++ b/tests/_data/fixtures/Session/Adapter/StreamGlobFixture.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Fixtures\Session\Adapter;
+
+use Phalcon\Session\Adapter\Stream;
+
+class StreamGlobFixture extends Stream
+{
+    /**
+     * Gets the glob array or returns false on failure
+     *
+     * @param string $pattern
+     *
+     * @return array|false
+     */
+    protected function getGlobFiles(string $pattern): array | false
+    {
+        return false;
+    }
+}

--- a/tests/_data/fixtures/Session/Adapter/StreamIsWritableFixture.php
+++ b/tests/_data/fixtures/Session/Adapter/StreamIsWritableFixture.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Fixtures\Session\Adapter;
+
+use Phalcon\Session\Adapter\Stream;
+
+class StreamIsWritableFixture extends Stream
+{
+    /**
+     * Tells whether the filename is writable
+     *
+     * @param string $filename
+     *
+     * @return bool
+     *
+     * @link https://php.net/manual/en/function.is-writable.php
+     */
+    protected function phpIsWritable(string $filename): bool
+    {
+        return false;
+    }
+}

--- a/tests/unit/Session/Adapter/ConstructTest.php
+++ b/tests/unit/Session/Adapter/ConstructTest.php
@@ -19,10 +19,10 @@ use Phalcon\Session\Adapter\Stream;
 use Phalcon\Session\Exception;
 use Phalcon\Storage\AdapterFactory;
 use Phalcon\Storage\SerializerFactory;
+use Phalcon\Tests\AbstractUnitTestCase;
 use Phalcon\Tests\Fixtures\Session\Adapter\StreamIsWritableFixture;
 use Phalcon\Tests\Fixtures\Traits\DiTrait;
 use Phalcon\Tests\Fixtures\Traits\SessionTrait;
-use Phalcon\Tests\AbstractUnitTestCase;
 use SessionHandlerInterface;
 
 use function getOptionsRedis;
@@ -87,45 +87,6 @@ final class ConstructTest extends AbstractUnitTestCase
     }
 
     /**
-     * Tests Phalcon\Session\Adapter\Stream :: __construct() -
-     * empty savePath throws exception
-     *
-     * @author Phalcon Team <team@phalcon.io>
-     * @since  2020-10-23
-     */
-    public function testSessionAdapterStreamWithNoSavePathThrowsException(): void
-    {
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('The session save path cannot be empty');
-
-        $options = [
-            'prefix'   => 'my-custom-prefix-',
-            'savePath' => '',
-        ];
-
-        $streamSession = new Stream($options);
-    }
-
-    /**
-     * Tests Phalcon\Session\Adapter\Stream :: __construct() -
-     * empty savePath throws exception
-     *
-     * @author Phalcon Team <team@phalcon.io>
-     * @since  2020-10-23
-     */
-    public function testSessionAdapterStreamWithNotWriteableSavePathThrowsException(): void
-    {
-        $options = getOptionsSessionStream();
-        $savePath = $options['savePath'];
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage(
-            'The session save path [' . $savePath . '] is not writable'
-        );
-
-        $streamSession = new StreamIsWritableFixture($options);
-    }
-
-    /**
      * Tests Phalcon\Session\Adapter\Redis :: __construct() - with custom prefix
      *
      * @author Phalcon Team <team@phalcon.io>
@@ -157,5 +118,44 @@ final class ConstructTest extends AbstractUnitTestCase
         $expected = 'test-data';
         $actual   = $redisStorage->get('my-session-prefixed-key');
         $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Tests Phalcon\Session\Adapter\Stream :: __construct() -
+     * empty savePath throws exception
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2020-10-23
+     */
+    public function testSessionAdapterStreamWithNoSavePathThrowsException(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('The session save path cannot be empty');
+
+        $options = [
+            'prefix'   => 'my-custom-prefix-',
+            'savePath' => '',
+        ];
+
+        $streamSession = new Stream($options);
+    }
+
+    /**
+     * Tests Phalcon\Session\Adapter\Stream :: __construct() -
+     * empty savePath throws exception
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2020-10-23
+     */
+    public function testSessionAdapterStreamWithNotWriteableSavePathThrowsException(): void
+    {
+        $options  = getOptionsSessionStream();
+        $savePath = $options['savePath'];
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage(
+            'The session save path [' . $savePath . '] is not writable'
+        );
+
+        $streamSession = new StreamIsWritableFixture($options);
     }
 }

--- a/tests/unit/Session/Adapter/ConstructTest.php
+++ b/tests/unit/Session/Adapter/ConstructTest.php
@@ -15,14 +15,18 @@ namespace Phalcon\Tests\Unit\Session\Adapter;
 
 use Phalcon\Session\Adapter\Libmemcached;
 use Phalcon\Session\Adapter\Redis;
+use Phalcon\Session\Adapter\Stream;
+use Phalcon\Session\Exception;
 use Phalcon\Storage\AdapterFactory;
 use Phalcon\Storage\SerializerFactory;
+use Phalcon\Tests\Fixtures\Session\Adapter\StreamIsWritableFixture;
 use Phalcon\Tests\Fixtures\Traits\DiTrait;
 use Phalcon\Tests\Fixtures\Traits\SessionTrait;
 use Phalcon\Tests\AbstractUnitTestCase;
 use SessionHandlerInterface;
 
 use function getOptionsRedis;
+use function getOptionsSessionStream;
 
 final class ConstructTest extends AbstractUnitTestCase
 {
@@ -80,6 +84,45 @@ final class ConstructTest extends AbstractUnitTestCase
         $expected = 'test-data';
         $actual   = $memcachedStorage->get('my-session-prefixed-key');
         $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Tests Phalcon\Session\Adapter\Stream :: __construct() -
+     * empty savePath throws exception
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2020-10-23
+     */
+    public function testSessionAdapterStreamWithNoSavePathThrowsException(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('The session save path cannot be empty');
+
+        $options = [
+            'prefix'   => 'my-custom-prefix-',
+            'savePath' => '',
+        ];
+
+        $streamSession = new Stream($options);
+    }
+
+    /**
+     * Tests Phalcon\Session\Adapter\Stream :: __construct() -
+     * empty savePath throws exception
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2020-10-23
+     */
+    public function testSessionAdapterStreamWithNotWriteableSavePathThrowsException(): void
+    {
+        $options = getOptionsSessionStream();
+        $savePath = $options['savePath'];
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage(
+            'The session save path [' . $savePath . '] is not writable'
+        );
+
+        $streamSession = new StreamIsWritableFixture($options);
     }
 
     /**

--- a/tests/unit/Session/Adapter/DestroyTest.php
+++ b/tests/unit/Session/Adapter/DestroyTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Phalcon\Tests\Unit\Session\Adapter;
 
-use Phalcon\Tests\Fixtures\Traits\DiTrait;
 use Phalcon\Tests\AbstractServicesTestCase;
+use Phalcon\Tests\Fixtures\Traits\DiTrait;
 
 use function cacheDir;
 use function file_put_contents;

--- a/tests/unit/Session/Adapter/GcTest.php
+++ b/tests/unit/Session/Adapter/GcTest.php
@@ -13,11 +13,10 @@ declare(strict_types=1);
 
 namespace Phalcon\Tests\Unit\Session\Adapter;
 
-use Phalcon\Session\Adapter\Stream as SessionStream;
 use Phalcon\Session\Exception;
+use Phalcon\Tests\AbstractServicesTestCase;
 use Phalcon\Tests\Fixtures\Session\Adapter\StreamGlobFixture;
 use Phalcon\Tests\Fixtures\Traits\DiTrait;
-use Phalcon\Tests\AbstractServicesTestCase;
 
 use function cacheDir;
 use function file_put_contents;

--- a/tests/unit/Session/Adapter/GcTest.php
+++ b/tests/unit/Session/Adapter/GcTest.php
@@ -13,11 +13,15 @@ declare(strict_types=1);
 
 namespace Phalcon\Tests\Unit\Session\Adapter;
 
+use Phalcon\Session\Adapter\Stream as SessionStream;
+use Phalcon\Session\Exception;
+use Phalcon\Tests\Fixtures\Session\Adapter\StreamGlobFixture;
 use Phalcon\Tests\Fixtures\Traits\DiTrait;
 use Phalcon\Tests\AbstractServicesTestCase;
 
 use function cacheDir;
 use function file_put_contents;
+use function getOptionsSessionStream;
 use function sleep;
 use function uniqid;
 
@@ -115,5 +119,24 @@ final class GcTest extends AbstractServicesTestCase
 
         $this->assertFileDoesNotExist(cacheDir('sessions/gc_1'));
         $this->assertFileDoesNotExist(cacheDir('sessions/gc_2'));
+    }
+
+    /**
+     * Tests Phalcon\Session\Adapter\Stream :: gc() -
+     * glob() false returns exception
+     *
+     * @return void
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2020-09-09
+     */
+    public function testSessionAdapterStreamGcGlobThrowsException(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Unexpected gc error');
+
+        $adapter = new StreamGlobFixture(getOptionsSessionStream());
+
+        $actual = $adapter->gc(1);
     }
 }

--- a/tests/unit/Session/Adapter/OpenCloseTest.php
+++ b/tests/unit/Session/Adapter/OpenCloseTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Phalcon\Tests\Unit\Session\Adapter;
 
+use Phalcon\Tests\AbstractUnitTestCase;
 use Phalcon\Tests\Fixtures\Traits\DiTrait;
 use Phalcon\Tests\Fixtures\Traits\SessionTrait;
-use Phalcon\Tests\AbstractUnitTestCase;
 
 final class OpenCloseTest extends AbstractUnitTestCase
 {

--- a/tests/unit/Session/Adapter/ReadWriteTest.php
+++ b/tests/unit/Session/Adapter/ReadWriteTest.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Phalcon\Tests\Unit\Session\Adapter;
 
 use Phalcon\Session\Adapter\Redis;
+use Phalcon\Tests\AbstractServicesTestCase;
 use Phalcon\Tests\Fixtures\Session\Adapter\StreamFileGetContentsFixture;
 use Phalcon\Tests\Fixtures\Traits\DiTrait;
-use Phalcon\Tests\AbstractServicesTestCase;
 
 use function cacheDir;
 use function getOptionsSessionStream;
@@ -128,7 +128,7 @@ final class ReadWriteTest extends AbstractServicesTestCase
     public function testSessionAdapterStreamReadNoData(): void
     {
         $adapter = new StreamFileGetContentsFixture(getOptionsSessionStream());
-        $value = uniqid();
+        $value   = uniqid();
         $adapter->write('test1', $value);
 
         $actual = $adapter->read('test1');


### PR DESCRIPTION
Hello!

*  Type: bug fix 
*  Link to issue: https://github.com/phalcon/cphalcon/issues/16713

**In raising this pull request, I confirm the following:**

-  [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/phalcon/blob/master/CONTRIBUTING.md)
-  [x] I have checked that another pull request for this purpose does not exist
-  [x] I wrote some tests for this PR
-  [ ] I have updated the relevant CHANGELOG
-  [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Session\Adapter\Stream::gc()` to throw an exception if something is wrong with `glob()`

Thanks
