### PR TITLE
adjusted getBasicAuth to return an empty pass if none is set

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -173,10 +173,7 @@ class Request extends AbstractInjectionAware implements
      */
     public function getBasicAuth(): array | null
     {
-        if (
-            true !== $this->hasServer('PHP_AUTH_USER') ||
-            true !== $this->hasServer('PHP_AUTH_PW')
-        ) {
+        if (true !== $this->hasServer('PHP_AUTH_USER')) {
             return null;
         }
 

--- a/tests/unit/Http/Request/GetBasicAuthTest.php
+++ b/tests/unit/Http/Request/GetBasicAuthTest.php
@@ -37,6 +37,26 @@ final class GetBasicAuthTest extends AbstractHttpBase
         ];
         $actual   = $request->getBasicAuth();
         $this->assertSame($expected, $actual);
+
+        /**
+         * @issue 16668
+         */
+        unset($_SERVER['PHP_AUTH_USER']);
+        unset($_SERVER['PHP_AUTH_PW']);
+
+        $_SERVER['PHP_AUTH_USER'] = 'darth';
+
+        $request = new Request();
+
+        $expected = [
+            'username' => 'darth',
+            'password' => null,
+        ];
+        $actual   = $request->getBasicAuth();
+        $this->assertSame($expected, $actual);
+
+        unset($_SERVER['PHP_AUTH_USER']);
+        unset($_SERVER['PHP_AUTH_PW']);
     }
 
     /**


### PR DESCRIPTION
Hello!

*  Type: bug fix
*  Link to issue: https://github.com/phalcon/cphalcon/issues/16668

**In raising this pull request, I confirm the following:**

-  [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/phalcon/blob/master/CONTRIBUTING.md)
-  [x] I have checked that another pull request for this purpose does not exist
-  [x] I wrote some tests for this PR
-  [ ] I have updated the relevant CHANGELOG
-  [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Http\Request::getBasicAuth()` to return a null password if not defined on the server

Thanks
