### PR TITLE
Trigger db commit event after event commit

### DIFF
--- a/src/Db/Adapter/Pdo/AbstractPdo.php
+++ b/src/Db/Adapter/Pdo/AbstractPdo.php
@@ -824,7 +824,11 @@ abstract class AbstractPdo extends AbstractAdapter
              */
             $this->transactionLevel--;
 
-            return $this->pdo->rollback();
+            $result = $this->pdo->rollback();
+
+            $this->fireManagerEvent('db:transactionRolledBack');
+
+            return $result;
         }
 
         /**

--- a/src/Db/Adapter/Pdo/AbstractPdo.php
+++ b/src/Db/Adapter/Pdo/AbstractPdo.php
@@ -200,11 +200,18 @@ abstract class AbstractPdo extends AbstractAdapter
 
             $result = $this->pdo->commit();
             /**
+             * When error mode is set to silent or warning we need to check result and trigger event only when
+             * $result is not false.
+             */
+            if ($result === false) {
+                return false;
+            }
+            /**
              * Notify the events manager about the committed transaction
              */
             $this->fireManagerEvent('db:transactionCommited');
 
-            return $result;
+            return true;
         }
 
         /**
@@ -238,11 +245,20 @@ abstract class AbstractPdo extends AbstractAdapter
         $result = $this->releaseSavepoint($savepointName);
 
         /**
+         * When error mode is set to silent or warning we need to check result and trigger event only when
+         * $result is not false.
+         */
+
+        if ($result === false) {
+            return false;
+        }
+
+        /**
          * Notify the events manager about the committed savepoint
          */
         $this->fireManagerEvent('db:savepointReleased', $savepointName);
 
-        return $result;
+        return true;
     }
 
     /**

--- a/src/Db/Adapter/Pdo/AbstractPdo.php
+++ b/src/Db/Adapter/Pdo/AbstractPdo.php
@@ -200,7 +200,7 @@ abstract class AbstractPdo extends AbstractAdapter
 
             $result = $this->pdo->commit();
             /**
-             * When error mode is set to silent or warning we need to check result and trigger event only when
+             * When error mode is set to silent or warning, we need to check result and trigger event only when
              * $result is not false.
              */
             if ($result === false) {
@@ -209,7 +209,7 @@ abstract class AbstractPdo extends AbstractAdapter
             /**
              * Notify the events manager about the committed transaction
              */
-            $this->fireManagerEvent('db:transactionCommited');
+            $this->fireManagerEvent('db:transactionCommitted');
 
             return true;
         }
@@ -245,7 +245,7 @@ abstract class AbstractPdo extends AbstractAdapter
         $result = $this->releaseSavepoint($savepointName);
 
         /**
-         * When error mode is set to silent or warning we need to check result and trigger event only when
+         * When error mode is set to silent or warning, we need to check result and trigger event only when
          * $result is not false.
          */
 

--- a/src/Db/Adapter/Pdo/AbstractPdo.php
+++ b/src/Db/Adapter/Pdo/AbstractPdo.php
@@ -198,7 +198,13 @@ abstract class AbstractPdo extends AbstractAdapter
              */
             $this->transactionLevel--;
 
-            return $this->pdo->commit();
+            $result = $this->pdo->commit();
+            /**
+             * Notify the events manager about the committed transaction
+             */
+            $this->fireManagerEvent('db:transactionCommited');
+
+            return $result;
         }
 
         /**
@@ -229,8 +235,14 @@ abstract class AbstractPdo extends AbstractAdapter
          * Reduce the transaction nesting level
          */
         $this->transactionLevel--;
+        $result = $this->releaseSavepoint($savepointName);
 
-        return $this->releaseSavepoint($savepointName);
+        /**
+         * Notify the events manager about the committed savepoint
+         */
+        $this->fireManagerEvent('db:savepointReleased', $savepointName);
+
+        return $result;
     }
 
     /**

--- a/src/Db/Adapter/Pdo/AbstractPdo.php
+++ b/src/Db/Adapter/Pdo/AbstractPdo.php
@@ -199,6 +199,7 @@ abstract class AbstractPdo extends AbstractAdapter
             $this->transactionLevel--;
 
             $result = $this->pdo->commit();
+
             /**
              * When error mode is set to silent or warning, we need to check result and trigger event only when
              * $result is not false.
@@ -206,6 +207,7 @@ abstract class AbstractPdo extends AbstractAdapter
             if ($result === false) {
                 return false;
             }
+
             /**
              * Notify the events manager about the committed transaction
              */
@@ -248,13 +250,12 @@ abstract class AbstractPdo extends AbstractAdapter
          * When error mode is set to silent or warning, we need to check result and trigger event only when
          * $result is not false.
          */
-
         if ($result === false) {
             return false;
         }
 
         /**
-         * Notify the events manager about the committed savepoint
+         * Notify the events manager about the released savepoint
          */
         $this->fireManagerEvent('db:savepointReleased', $savepointName);
 

--- a/tests/database/Db/Adapter/Pdo/EventsTest.php
+++ b/tests/database/Db/Adapter/Pdo/EventsTest.php
@@ -1,0 +1,152 @@
+<?php
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Database\Db\Adapter\Pdo;
+
+use PDO;
+use Phalcon\Db\Adapter\Pdo\Sqlite;
+use Phalcon\Events\Manager;
+use Phalcon\Tests\Unit\AbstractUnitTestCase;
+
+final class EventsTest extends AbstractUnitTestCase
+{
+    public function eventsProvider(): array
+    {
+        return [
+            ['SELECT 1', 'query', ['beforeQuery', 'afterQuery']],
+            ['CREATE TABLE test (id INT)', 'execute', ['beforeQuery', 'afterQuery']],
+            ['', 'commit', ['beginTransaction', 'commitTransaction', 'transactionCommitted']],
+            ['', 'rollback', ['beginTransaction', 'rollbackTransaction', 'transactionRolledBack']],
+        ];
+    }
+
+    /**
+     * @dataProvider eventsProvider
+     */
+    public function testEvents($sql, $event, array $expectedEvents = []): void
+    {
+        $connection = new Sqlite([
+            'dbname' => ':memory:',
+        ]);
+
+        $manager = new Manager();
+        $connection->setEventsManager($manager);
+
+        $listener = new class {
+            public array $events = [];
+
+            public function beforeQuery($event, $adapter, mixed $data = null)
+            {
+                $this->events[] = __FUNCTION__;
+            }
+
+            public function afterQuery($event, $adapter, mixed $data = null)
+            {
+                $this->events[] = __FUNCTION__;
+            }
+
+            public function commitTransaction($event, $adapter, mixed $data = null)
+            {
+                $this->events[] = __FUNCTION__;
+            }
+
+            public function beginTransaction($event, $adapter, mixed $data = null)
+            {
+                $this->events[] = __FUNCTION__;
+            }
+
+            public function transactionCommitted($event, $adapter, mixed $data = null)
+            {
+                $this->events[] = __FUNCTION__;
+            }
+
+            public function rollbackTransaction($event, $adapter, mixed $data = null)
+            {
+                $this->events[] = __FUNCTION__;
+            }
+
+            public function transactionRolledBack($event, $adapter, mixed $data = null)
+            {
+                $this->events[] = __FUNCTION__;
+            }
+        };
+
+        $manager->attach('db', $listener);
+
+        // Execute the SQL and check events based on the example data
+        switch ($event) {
+            case 'query':
+                $connection->query($sql);
+                break;
+
+            case 'execute':
+                $connection->execute($sql);
+                break;
+
+            case 'commit':
+                $connection->begin();
+                $connection->execute(
+                    'CREATE TABLE test (id INT)'
+                );
+                $connection->commit();
+                break;
+
+            case 'rollback':
+                $connection->begin();
+                $connection->execute(
+                    'CREATE TABLE test (id INT)'
+                ); // Needs a query inside transaction for rollback to trigger
+                $connection->rollback();
+                break;
+        }
+
+        foreach($expectedEvents as $expectedEvent) {
+            $this->assertContains($expectedEvent, $listener->events);
+        }
+    }
+
+    public function testBadCommit(): void
+    {
+        $mockPDO = $this->getMockBuilder(PDO::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['commit'])
+            ->getMock();
+
+        $mockPDO->expects($this->once())->method('commit')->willReturn(false);
+
+        $connection = new Sqlite([
+            'dbname' => ':memory:',
+        ]);
+        $ref = new \ReflectionObject($connection);
+
+        $property = $ref->getProperty('pdo');
+        $property->setAccessible(true);
+        $property->setValue($connection, $mockPDO);
+
+        $property = $ref->getProperty('transactionLevel');
+        $property->setAccessible(true);
+        $property->setValue($connection, 1);
+
+        $manager = new Manager();
+        $connection->setEventsManager($manager);
+
+        $listener = new class {
+            public array $events = [];
+
+            public function commitTransaction($event, $adapter, mixed $data = null)
+            {
+                $this->events[] = __FUNCTION__;
+            }
+            public function transactionCommitted($event, $adapter, mixed $data = null)
+            {
+                $this->events[] = __FUNCTION__;
+            }
+        };
+
+        $manager->attach('db', $listener);
+
+        $connection->commit();
+        $this->assertContains('commitTransaction', $listener->events);
+        $this->assertNotContains('transactionCommitted', $listener->events);
+    }
+}

--- a/tests/database/Db/Adapter/Pdo/EventsTest.php
+++ b/tests/database/Db/Adapter/Pdo/EventsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phalcon\Tests\Database\Db\Adapter\Pdo;
@@ -100,7 +101,7 @@ final class EventsTest extends AbstractUnitTestCase
                 break;
         }
 
-        foreach($expectedEvents as $expectedEvent) {
+        foreach ($expectedEvents as $expectedEvent) {
             $this->assertContains($expectedEvent, $listener->events);
         }
     }


### PR DESCRIPTION
Hello!

*  Type:new feature

**In raising this pull request, I confirm the following:**

-  [ ] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/phalcon/blob/master/CONTRIBUTING.md)
-  [ ] I have checked that another pull request for this purpose does not exist
-  [ ] I wrote some tests for this PR
-  [ ] I have updated the relevant CHANGELOG
-  [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

Notify the events manager when a transaction is committed or a savepoint is released. This enhances observability and allows external systems to react to these database operations.

Thanks
