### PR TITLE
Fix transaction event trigger order

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: "Setup PHP"
-        uses: shivammathur/setup-php@v2.32.0
+        uses: shivammathur/setup-php@2.32.0
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ env.EXTENSIONS }}
@@ -145,7 +145,7 @@ jobs:
           redis-cli -h 127.0.0.1 -p 5000 cluster nodes
 
       - name: "Setup PHP"
-        uses: shivammathur/setup-php@v2.32.0
+        uses: shivammathur/setup-php@2.32.0
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ env.EXTENSIONS }}
@@ -240,7 +240,7 @@ jobs:
           git config --global core.autocrlf false
 
       - name: "Setup PHP"
-        uses: shivammathur/setup-php@v2.32.0
+        uses: shivammathur/setup-php@2.32.0
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ env.EXTENSIONS }}
@@ -329,7 +329,7 @@ jobs:
   #          git config --global core.autocrlf false
   #
   #      - name: "Setup PHP"
-  #        uses: shivammathur/setup-php@v2.32.0
+  #        uses: shivammathur/setup-php@2.32.0
   #        with:
   #          php-version: ${{ matrix.php }}
   #          extensions: ${{ env.EXTENSIONS }}
@@ -397,7 +397,7 @@ jobs:
           git config --global core.autocrlf false
 
       - name: "Setup PHP"
-        uses: shivammathur/setup-php@v2.32.0
+        uses: shivammathur/setup-php@2.32.0
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ env.EXTENSIONS }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: "Setup PHP"
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@v2.32.0
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ env.EXTENSIONS }}
@@ -145,7 +145,7 @@ jobs:
           redis-cli -h 127.0.0.1 -p 5000 cluster nodes
 
       - name: "Setup PHP"
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@v2.32.0
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ env.EXTENSIONS }}
@@ -240,7 +240,7 @@ jobs:
           git config --global core.autocrlf false
 
       - name: "Setup PHP"
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@v2.32.0
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ env.EXTENSIONS }}
@@ -329,7 +329,7 @@ jobs:
   #          git config --global core.autocrlf false
   #
   #      - name: "Setup PHP"
-  #        uses: shivammathur/setup-php@v2
+  #        uses: shivammathur/setup-php@v2.32.0
   #        with:
   #          php-version: ${{ matrix.php }}
   #          extensions: ${{ env.EXTENSIONS }}
@@ -397,7 +397,7 @@ jobs:
           git config --global core.autocrlf false
 
       - name: "Setup PHP"
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@v2.32.0
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ env.EXTENSIONS }}

--- a/src/Db/Adapter/Pdo/AbstractPdo.php
+++ b/src/Db/Adapter/Pdo/AbstractPdo.php
@@ -189,16 +189,21 @@ abstract class AbstractPdo extends AbstractAdapter
 
         if (1 === $this->transactionLevel) {
             /**
-             * Notify the events manager about the committed transaction
-             */
-            $this->fireManagerEvent("db:commitTransaction");
-
-            /**
              * Reduce the transaction nesting level
              */
             $this->transactionLevel--;
 
-            return $this->pdo->commit();
+            /**
+             * Commit the transaction and store the result
+             */
+            $commitResult = $this->pdo->commit();
+
+            /**
+             * Notify the events manager about the committed transaction
+             */
+            $this->fireManagerEvent("db:commitTransaction");
+
+            return $commitResult;
         }
 
         /**


### PR DESCRIPTION
Fixes #627

Stored the `commit()` result in a variable. Moved the event fire below the `commit()` operation and then returned the stored `commit()` result

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/phalcon/phalcon/pull/628?shareId=0a4fb4a1-47fe-4773-b1f6-e3c1acb0810c).