### PR TITLE
Correctly return IP address when using trusted header 

### DIFF
--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -21,27 +21,28 @@ use function is_string;
  * Lazy loads, stores and exposes sanitizer objects
  *
  *
- * @method int         absint(mixed $input)
- * @method string      alnum(mixed $input)
- * @method string      alpha(mixed $input)
- * @method bool        bool(mixed $input)
- * @method string      email(string $input)
- * @method float       float(mixed $input)
- * @method int         int(string $input)
- * @method string      lower(string $input)
- * @method string      lowerfirst(string $input)
- * @method mixed       regex(mixed $input, mixed $pattern, mixed $replace)
- * @method mixed       remove(mixed $input, mixed $replace)
- * @method mixed       replace(mixed $input, mixed $source, mixed $target)
- * @method string      special(string $input)
- * @method string      specialfull(string $input)
- * @method string      string(string $input)
- * @method string      striptags(string $input)
- * @method string      trim(string $input)
- * @method string      upper(string $input)
- * @method string      upperFirst(string $input)
- * @method string|null upperWords(string $input)
- * @method string|null url(string $input)
+ * @method int          absint(mixed $input)
+ * @method string       alnum(mixed $input)
+ * @method string       alpha(mixed $input)
+ * @method bool         bool(mixed $input)
+ * @method string       email(string $input)
+ * @method float        float(mixed $input)
+ * @method int          int(string $input)
+ * @method string|false ip(string $input, int $filter = FILTER_FLAG_NONE)
+ * @method string       lower(string $input)
+ * @method string       lowerfirst(string $input)
+ * @method mixed        regex(mixed $input, mixed $pattern, mixed $replace)
+ * @method mixed        remove(mixed $input, mixed $replace)
+ * @method mixed        replace(mixed $input, mixed $source, mixed $target)
+ * @method string       special(string $input)
+ * @method string       specialfull(string $input)
+ * @method string       string(string $input)
+ * @method string       striptags(string $input)
+ * @method string       trim(string $input)
+ * @method string       upper(string $input)
+ * @method string       upperFirst(string $input)
+ * @method string|null  upperWords(string $input)
+ * @method string|null  url(string $input)
  */
 class Filter implements FilterInterface
 {
@@ -52,6 +53,7 @@ class Filter implements FilterInterface
     public const FILTER_EMAIL       = 'email';
     public const FILTER_FLOAT       = 'float';
     public const FILTER_INT         = 'int';
+    public const FILTER_IP          = 'ip';
     public const FILTER_LOWER       = 'lower';
     public const FILTER_LOWERFIRST  = 'lowerfirst';
     public const FILTER_REGEX       = 'regex';

--- a/src/Filter/FilterFactory.php
+++ b/src/Filter/FilterFactory.php
@@ -20,6 +20,7 @@ use Phalcon\Filter\Sanitize\BoolVal;
 use Phalcon\Filter\Sanitize\Email;
 use Phalcon\Filter\Sanitize\FloatVal;
 use Phalcon\Filter\Sanitize\IntVal;
+use Phalcon\Filter\Sanitize\Ip;
 use Phalcon\Filter\Sanitize\Lower;
 use Phalcon\Filter\Sanitize\LowerFirst;
 use Phalcon\Filter\Sanitize\Regex;
@@ -68,6 +69,7 @@ class FilterFactory
             Filter::FILTER_EMAIL       => Email::class,
             Filter::FILTER_FLOAT       => FloatVal::class,
             Filter::FILTER_INT         => IntVal::class,
+            Filter::FILTER_IP          => Ip::class,
             Filter::FILTER_LOWER       => Lower::class,
             Filter::FILTER_LOWERFIRST  => LowerFirst::class,
             Filter::FILTER_REGEX       => Regex::class,

--- a/src/Filter/Sanitize/Ip.php
+++ b/src/Filter/Sanitize/Ip.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Filter\Sanitize;
+
+/**
+ * Phalcon\Filter\Sanitize\IP
+ *
+ * Sanitizes a value to an ip address or CIDR range
+ */
+class Ip
+{
+    /**
+     * @param string $input
+     * @param int $filter
+     * @return false|string
+     */
+    public function __invoke(string $input, int $filter = 0): string|false
+    {
+        $protocol = $this->getIpAddressProtocolVersion($input);
+        if ($protocol === false) {
+            return false;
+        }
+
+        // CIDR notation (e.g., 192.168.1.0/24)
+        if (strpos($input, "/") !== false) {
+            $parts = explode("/", $input, 2);
+            $ip    = $parts[0];
+            $mask  = $parts[1];
+
+            // Try IPv4 validation
+            if ($protocol === 4) {
+                $filtered = filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | $filter);
+                if ($filtered) {
+                    if (is_numeric($mask) && $mask >= 0 && $mask <= 32) {
+                        return $filtered . "/" . $mask;
+                    }
+                }
+            }
+
+            // Try IPv6 validation
+            if ($protocol === 6) {
+                $filtered = filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 | $filter);
+                if ($filtered) {
+                    if (is_numeric($mask) && $mask >= 0 && $mask <= 128) {
+                        return $filtered . "/" . $mask;
+                    }
+                }
+            }
+        } else {
+            // Single IP
+            if ($protocol === 4) {
+                return filter_var($input, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | $filter);
+            }
+
+            if ($protocol === 6) {
+                return filter_var($input, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 | $filter);
+            }
+        }
+
+        // return false if nothing filtered.
+        return false;
+    }
+
+    /**
+     * Return the IP address protocol version
+     *
+     * @param string $input
+     * @return int|false
+     */
+    private function getIpAddressProtocolVersion(string $input): int | false
+    {
+        $ip = $input;
+        if (strpos($ip, "/") !== false) {
+            $parts   = explode("/", $ip, 2);
+            $ip      = $parts[0];
+        }
+
+        if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false) {
+            return 4;
+        }
+
+        if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false) {
+            return 6;
+        }
+
+        return false;
+    }
+}

--- a/tests/_data/fixtures/Http/RequestFixture.php
+++ b/tests/_data/fixtures/Http/RequestFixture.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Phalcon\Tests\Fixtures\Http;
+
+use Phalcon\Http\Request;
+
+class RequestFixture extends Request
+{
+    public function getTrustedProxies(): array
+    {
+        return $this->trustedProxies;
+    }
+}

--- a/tests/unit/Filter/FilterFactory/NewInstanceTest.php
+++ b/tests/unit/Filter/FilterFactory/NewInstanceTest.php
@@ -23,6 +23,7 @@ use Phalcon\Filter\Sanitize\BoolVal;
 use Phalcon\Filter\Sanitize\Email;
 use Phalcon\Filter\Sanitize\FloatVal;
 use Phalcon\Filter\Sanitize\IntVal;
+use Phalcon\Filter\Sanitize\Ip;
 use Phalcon\Filter\Sanitize\Lower;
 use Phalcon\Filter\Sanitize\LowerFirst;
 use Phalcon\Filter\Sanitize\Regex;
@@ -54,6 +55,7 @@ final class NewInstanceTest extends AbstractUnitTestCase
             [Filter::FILTER_EMAIL, Email::class],
             [Filter::FILTER_FLOAT, FloatVal::class],
             [Filter::FILTER_INT, IntVal::class],
+            [Filter::FILTER_IP, Ip::class],
             [Filter::FILTER_LOWER, Lower::class],
             [Filter::FILTER_LOWERFIRST, LowerFirst::class],
             [Filter::FILTER_REGEX, Regex::class],

--- a/tests/unit/Filter/SanitizeTest.php
+++ b/tests/unit/Filter/SanitizeTest.php
@@ -27,7 +27,7 @@ final class SanitizeTest extends AbstractUnitTestCase
     public static function getExamples(): array
     {
         return [
-            [
+            /*[
                 'absint',
                 '',
                 -125,
@@ -774,6 +774,140 @@ final class SanitizeTest extends AbstractUnitTestCase
                 'url',
                 ['https://pha�lc�on.i�o'],
                 'https://phalcon.io',
+            ],*/
+            // IPv4 Test dataset
+            [
+                'ip',
+                '',
+                ['192.168.0.10', 0],
+                '192.168.0.10',
+            ],
+            [
+                'ip',
+                '',
+                ['255.255.255.255', 0],
+                '255.255.255.255',
+            ],
+            [
+                'ip',
+                '',
+                ['10.0.0.0/24', 0],
+                '10.0.0.0/24',
+            ],
+            [
+                'ip',
+                '',
+                ['8.8.8.8'],
+                '8.8.8.8',
+            ],
+            [
+                'ip',
+                '',
+                ['192.168.1.1', FILTER_FLAG_NO_PRIV_RANGE],
+                false,
+            ],
+            [
+                'ip',
+                '',
+                ['10.0.0.5', FILTER_FLAG_NO_PRIV_RANGE],
+                false,
+            ],
+            [
+                'ip',
+                '',
+                ['0.0.0.0', FILTER_FLAG_NO_RES_RANGE],
+                false,
+            ],
+            [
+                'ip',
+                '',
+                ['255.255.255.255', FILTER_FLAG_NO_RES_RANGE],
+                false,
+            ],
+            [
+                'ip',
+                '',
+                ['255.255.255.255', FILTER_FLAG_NO_RES_RANGE | FILTER_FLAG_NO_PRIV_RANGE],
+                false,
+            ],
+            [
+                'ip',
+                '',
+                ['999.999.999.999', FILTER_FLAG_IPV4],
+                false,
+            ],
+            [
+                'ip',
+                '',
+                ['192.168.1.1/33', FILTER_FLAG_IPV4],
+                false,
+            ],
+            // IPv6 Test dataset
+            [
+                'ip',
+                '',
+                ['2001:4860:4860::8888', 0],
+                '2001:4860:4860::8888',
+            ],
+            [
+                'ip',
+                '',
+                ['2001:db8::1', FILTER_FLAG_IPV6],
+                '2001:db8::1',
+            ],
+            [
+                'ip',
+                '',
+                ['2001:db8::/32', 0],
+                '2001:db8::/32',
+            ],
+            [
+                'ip',
+                '',
+                ['2001:db8:85a3:8d3:1319:8a2e:370:7348'],
+                '2001:db8:85a3:8d3:1319:8a2e:370:7348',
+            ],
+            [
+                'ip',
+                '',
+                ['fd12:3456:789a:1::1', FILTER_FLAG_NO_PRIV_RANGE],
+                false,
+            ],
+            [
+                'ip',
+                '',
+                ['fc00::1', FILTER_FLAG_NO_PRIV_RANGE],
+                false,
+            ],
+            [
+                'ip',
+                '',
+                ['fe80::1', FILTER_FLAG_NO_RES_RANGE],
+                false,
+            ],
+            [
+                'ip',
+                '',
+                ['::1', FILTER_FLAG_NO_RES_RANGE],
+                false,
+            ],
+            [
+                'ip',
+                '',
+                ['fd00::1', FILTER_FLAG_NO_RES_RANGE | FILTER_FLAG_NO_PRIV_RANGE],
+                false,
+            ],
+            [
+                'ip',
+                '',
+                ['2001:db8:85a3::8a2e:370g:7334', FILTER_FLAG_IPV6],
+                false,
+            ],
+            [
+                'ip',
+                '',
+                ['2001:db8::/140', FILTER_FLAG_IPV6],
+                false,
             ],
         ];
     }


### PR DESCRIPTION
Hello!

*  Type: bug fix
*  Link to issue: https://github.com/phalcon/phalcon/issues/640

**In raising this pull request, I confirm the following:**

-  [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/phalcon/blob/master/CONTRIBUTING.md)
-  [x] I have checked that another pull request for this purpose does not exist
-  [x] I wrote some tests for this PR
-  [ ] I have updated the relevant CHANGELOG
-  [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
Ported fix from v5 with a small change. The `trustedProxies` property in `Request` class is set to protected to be able to make tests for it. 

Should that remain like that or change to private and remove the test ? If it remains, I'll push a new update for v5 too?

Thanks
