### PR TITLE
Removed method getPatchPut() and passed post|patch|put to new parsing method

### DIFF
--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -8,7 +8,6 @@ define('PROJECT_PATH', $root);
 require_once $root . 'tests/_config/functions.php';
 
 loadIni();
-loadAutoloader($root);
 loadFolders();
 loadDefined();
 

--- a/tests/unit/Http/Request/GetPostTest.php
+++ b/tests/unit/Http/Request/GetPostTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Phalcon\Tests\Unit\Http\Request;
 
 use Phalcon\Storage\Exception;
+use Phalcon\Tests\Fixtures\Page\Http;
 use Phalcon\Tests\Unit\Http\Helper\AbstractHttpBase;
 
 use function strtolower;
@@ -46,6 +47,44 @@ final class GetPostTest extends AbstractHttpBase
         $expected = $value;
         $actual   = $request->getPost($key);
         $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Tests Phalcon\Http\Request :: getPost() - json
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2025-07-22
+     */
+    public function testHttpRequestGetPostJson(): void
+    {
+        $this->registerStream();
+
+        file_put_contents(
+            Http::STREAM,
+            '{"fruit": "orange", "quantity": "4"}'
+        );
+
+        $_SERVER['REQUEST_METHOD'] = Http::METHOD_POST;
+        $_SERVER['CONTENT_TYPE']   = Http::CONTENT_TYPE_JSON;
+
+        $request = $this->getRequestObject();
+
+        $expected = [
+            'fruit'    => 'orange',
+            'quantity' => '4',
+        ];
+
+        $actual = json_decode(
+            file_get_contents(Http::STREAM),
+            true
+        );
+
+        $this->assertSame($expected, $actual);
+
+        $actual = $request->getPost();
+        $this->assertSame($expected, $actual);
+
+        $this->unregisterStream();
     }
 
     /**

--- a/tests/unit/Http/Request/IsTest.php
+++ b/tests/unit/Http/Request/IsTest.php
@@ -167,6 +167,13 @@ final class IsTest extends AbstractHttpBase
                 true,
                 'isSoap',
             ],
+            [
+                [
+                    'CONTENT_TYPE' => 'application/json',
+                ],
+                true,
+                'isJson',
+            ],
         ];
     }
 


### PR DESCRIPTION
Hello!

*  Type: bug fix
*  Link to issue: https://github.com/phalcon/phalcon/issues/645

**In raising this pull request, I confirm the following:**

-  [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/phalcon/blob/master/CONTRIBUTING.md)
-  [x] I have checked that another pull request for this purpose does not exist
-  [x] I wrote some tests for this PR
-  [ ] I have updated the relevant CHANGELOG
-  [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
Ported fix from v5 with some minor changes:
- the `getFormData()` method is missing completely, not sure why *a future todo ?*, so I skipped it
- the missing function was removed from the bootstrap test file

Thanks
