### PR TITLE
Fix array key type issue from numeric uniqid() values

### DIFF
--- a/tests/unit/Cache/Cache/DeleteMultipleTest.php
+++ b/tests/unit/Cache/Cache/DeleteMultipleTest.php
@@ -36,10 +36,10 @@ final class DeleteMultipleTest extends AbstractUnitTestCase
 
         $adapter = new Cache($instance);
 
-        $key1 = uniqid();
-        $key2 = uniqid();
-        $key3 = uniqid();
-        $key4 = uniqid();
+        $key1 = uniqid('key-');
+        $key2 = uniqid('key-');
+        $key3 = uniqid('key-');
+        $key4 = uniqid('key-');
 
         $adapter->setMultiple(
             [


### PR DESCRIPTION
Hello!

*  Type: bug fix
*  Link to issue:

**In raising this pull request, I confirm the following:**

-  [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/phalcon/blob/master/CONTRIBUTING.md)
-  [x] I have checked that another pull request for this purpose does not exist
-  [x] I wrote some tests for this PR
-  [x] I have updated the relevant CHANGELOG
-  [x] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

I noticed that [this commit](https://github.com/phalcon/phalcon/commit/5d2c9c374bb22e016a710284b0eb085e890bbb8e) failed one of the [unit test jobs](https://github.com/phalcon/phalcon/actions/runs/16720947456/job/47325246381) due to an edge case with `uniqid()`.

`uniqid()` usually returns an alphanumeric value, but as it is random, sometimes the value can be purely numeric.

Although a string, when it gets added to the array in Config, it gets converted to integer array key (`$array['123'] === $array[123]`) and bad things happen. 😛 

Now these keys will always be treated as strings, preventing automatic integer key conversion.