### PR TITLE
Corrected variable assignment placing.

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,4 @@ parameters:
         - src
     level: 1
     ignoreErrors:
-        -
-            message: '#Static access to instance property Phalcon\\Support\\Debug::\$isActive.#'
-            path: src/Support/Debug.php
         - "#Unsafe usage of new static#"

--- a/src/Mvc/Micro.php
+++ b/src/Mvc/Micro.php
@@ -389,6 +389,12 @@ class Micro extends Injectable implements ArrayAccess, EventsAwareInterface
                  * Updating active handler
                  */
                 $handler = $this->handlers[$matchedRoute->getRouteId()];
+
+                /**
+                 * Updating active handler
+                 */
+                $this->activeHandler = $handler;
+
                 if (null !== $this->eventsManager) {
                     /**
                      * Calling beforeExecuteRoute event
@@ -400,8 +406,7 @@ class Micro extends Injectable implements ArrayAccess, EventsAwareInterface
                     $handler = $this->activeHandler;
                 }
 
-                $this->activeHandler = $handler;
-                $this->stopped       = false;
+                $this->stopped = false;
 
                 /**
                  * Calls the before handlers


### PR DESCRIPTION
I saw that [one of my tests failed](https://github.com/SidRoberts/phalcon/actions/runs/18023324448/job/51285516631#step:12:127) due to `$handler` being `null` and tracked it down to a variable assignment being placed later than it was in the Zephir code:

- https://github.com/phalcon/cphalcon/blob/v5.9.3/phalcon/Mvc/Micro.zep#L438
- https://github.com/phalcon/phalcon/blob/v6.0.x/src/Mvc/Micro.php#L403