### PR TITLE
Fixed new Code Sniffer issues

### DIFF
--- a/tests/unit/Mvc/Dispatcher/Helper/DispatcherTestDefaultNoNamespaceController.php
+++ b/tests/unit/Mvc/Dispatcher/Helper/DispatcherTestDefaultNoNamespaceController.php
@@ -1,9 +1,6 @@
-<?php
+<?php // phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
 
-// @codingStandardsIgnoreStart
 use Phalcon\Mvc\Controller;
-
-// @codingStandardsIgnoreSEnd
 
 /**
  * \DispatcherTestDefaultNoNamespaceController

--- a/tests/unit/Mvc/Dispatcher/Helper/DispatcherTestDefaultNoNamespaceController.php
+++ b/tests/unit/Mvc/Dispatcher/Helper/DispatcherTestDefaultNoNamespaceController.php
@@ -20,8 +20,8 @@ use Phalcon\Mvc\Controller;
  */
 class DispatcherTestDefaultNoNamespaceController extends Controller
 {
-    const RETURN_VALUE_INT    = 5;
-    const RETURN_VALUE_STRING = 'string';
+    public const RETURN_VALUE_INT    = 5;
+    public const RETURN_VALUE_STRING = 'string';
 
     public function afterExecuteRoute()
     {


### PR DESCRIPTION
Phalcon is now running Code Sniffer 4 since https://github.com/phalcon/phalcon/commit/e0f4f0dcf30dd1381c519243f3571edf2d34736f.

Version 4 removed support for `@codingStandards`. It is succeeded by `phpcs:` comments (available since 3.2): https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/975

Previously failing test: https://github.com/phalcon/phalcon/actions/runs/18040476300/job/51337764221#step:5:68
