### PR TITLE
Fix method checkCipherHashIsAvailable()

### DIFF
--- a/src/Encryption/Crypt.php
+++ b/src/Encryption/Crypt.php
@@ -589,7 +589,7 @@ class Crypt implements CryptInterface
     protected function checkCipherHashIsAvailable(string $cipher, string $type): void
     {
         $method = "getAvailable";
-        $method .= ("hash" === $cipher) ? "HashAlgorithms" : "Ciphers";
+        $method .= ("hash" === $type) ? "HashAlgorithms" : "Ciphers";
         /** @var array<array-key, string> $available */
         $available = $this->$method();
         $lower     = $this->toLower($cipher);

--- a/src/Encryption/Crypt.php
+++ b/src/Encryption/Crypt.php
@@ -593,7 +593,7 @@ class Crypt implements CryptInterface
         /** @var array<array-key, string> $available */
         $available = $this->$method();
         $lower     = $this->toLower($cipher);
-        if (!isset($available[$lower])) {
+        if (!in_array($lower, $available)) {
             throw new Exception(
                 sprintf(
                     "The %s algorithm '%s' is not supported on this system.",

--- a/tests/unit/Encryption/Crypt/GetSetHashAlgorithmTest.php
+++ b/tests/unit/Encryption/Crypt/GetSetHashAlgorithmTest.php
@@ -29,7 +29,7 @@ final class GetSetHashAlgorithmTest extends AbstractUnitTestCase
      */
     public function testEncryptionCryptGetSetHashAlgo(): void
     {
-        $cipher = 'aes-128-cbc';
+        $cipher = 'sha384';
         $crypt  = new Crypt();
         $crypt->setHashAlgorithm($cipher);
 


### PR DESCRIPTION
Hello!

*  Type: bug fix
*  Link to issue: https://github.com/phalcon/cphalcon/issues/16822

**In raising this pull request, I confirm the following:**

-  [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/phalcon/blob/master/CONTRIBUTING.md)
-  [x] I have checked that another pull request for this purpose does not exist
-  [x] I wrote some tests for this PR
-  [ ] I have updated the relevant CHANGELOG
-  [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
Porting fix from v5, also fix the test related to this issue

Thanks
