### PR TITLE
Refactor `Forms\Element\Select` to use `TagFactory` instead of `Tag\Select`

### DIFF
--- a/src/Forms/Element/AbstractElement.php
+++ b/src/Forms/Element/AbstractElement.php
@@ -16,9 +16,8 @@ namespace Phalcon\Forms\Element;
 use InvalidArgumentException;
 use Phalcon\Di\Di;
 use Phalcon\Filter\Validation\ValidatorInterface;
+use Phalcon\Forms\Exception;
 use Phalcon\Forms\Form;
-use Phalcon\Html\Escaper;
-use Phalcon\Html\Escaper\EscaperInterface;
 use Phalcon\Html\TagFactory;
 use Phalcon\Messages\MessageInterface;
 use Phalcon\Messages\Messages;
@@ -591,22 +590,13 @@ abstract class AbstractElement implements ElementInterface
             if (null === $tagFactory) {
                 $container = Di::getDefault();
 
-                if (true === $container->has("tag")) {
+                if (null !== $container && true === $container->has("tag")) {
                     $tagFactory = $container->getShared("tag");
                 }
             }
 
-            /**
-             * All failed, create a new TagFactory
-             */
             if (null === $tagFactory) {
-                $container = Di::getDefault();
-                $escaper   = $container->getShared("escaper");
-                if (!($escaper instanceof EscaperInterface)) {
-                    $escaper = new Escaper();
-                }
-
-                $tagFactory = new TagFactory($escaper);
+                throw Exception::tagFactoryNotFound();
             }
 
             $this->tagFactory = $tagFactory;

--- a/src/Forms/Element/Select.php
+++ b/src/Forms/Element/Select.php
@@ -13,8 +13,10 @@ declare(strict_types=1);
 
 namespace Phalcon\Forms\Element;
 
-use Phalcon\Tag\Exception as TagException;
-use Phalcon\Tag\Select as SelectTag;
+use Phalcon\Forms\Exception;
+use Phalcon\Html\Helper\Input\Select\ArrayData;
+use Phalcon\Html\Helper\Input\Select\ResultsetData;
+use Phalcon\Mvc\Model\ResultsetInterface;
 
 use function is_array;
 
@@ -81,17 +83,63 @@ class Select extends AbstractElement
      * @param array $attributes
      *
      * @return string
-     * @throws TagException
      */
     public function render(array $attributes = []): string
     {
-        /**
-         * Merged passed attributes with previously defined ones
-         */
-        return SelectTag::selectField(
-            $this->prepareAttributes($attributes),
-            $this->optionsValues
-        );
+        $attrs = $this->prepareAttributes($attributes);
+
+        $name = $attrs[0];
+        unset($attrs[0]);
+
+        $value = $attrs['value'] ?? null;
+        unset($attrs['value']);
+
+        $useEmpty   = $attrs['useEmpty'] ?? false;
+        $emptyValue = $attrs['emptyValue'] ?? '';
+        $emptyText  = $attrs['emptyText'] ?? 'Choose...';
+        $using      = $attrs['using'] ?? null;
+
+        unset($attrs['useEmpty'], $attrs['emptyValue'], $attrs['emptyText'], $attrs['using']);
+
+        if (!isset($attrs['name'])) {
+            $attrs['name'] = $name;
+        }
+
+        if (!str_contains($name, '[') && !isset($attrs['id'])) {
+            $attrs['id'] = $name;
+        }
+
+        $select = $this->getLocalTagFactory()->newInstance('inputSelect');
+        $select('', '', $attrs);
+
+        if (null !== $value) {
+            $select->selected((string) $value);
+        }
+
+        if ($useEmpty) {
+            $select->addPlaceholder($emptyText, $emptyValue, [], true);
+        }
+
+        $options = $this->optionsValues;
+
+        if (is_array($options)) {
+            $select->fromData(new ArrayData($options));
+        } elseif ($options instanceof ResultsetInterface) {
+            if (null === $using || !is_array($using)) {
+                throw Exception::usingParameterRequired();
+            }
+
+            $select->fromData(new ResultsetData($options, $using));
+        }
+
+        $html = (string) $select;
+
+        if ('' === $html) {
+            return $this->getLocalTagFactory()
+                        ->newInstance('element')('select', PHP_EOL, $attrs, true);
+        }
+
+        return $html;
     }
 
     /**

--- a/src/Forms/Exception.php
+++ b/src/Forms/Exception.php
@@ -18,4 +18,15 @@ namespace Phalcon\Forms;
  */
 class Exception extends \Exception
 {
+    public static function tagFactoryNotFound(): self
+    {
+        return new self(
+            "A TagFactory must be provided via setTagFactory() or through a parent Form"
+        );
+    }
+
+    public static function usingParameterRequired(): self
+    {
+        return new self("The 'using' parameter is required for resultset options");
+    }
 }

--- a/src/Html/Helper/FriendlyTitle.php
+++ b/src/Html/Helper/FriendlyTitle.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Html\Helper;
+
+use Exception as BaseException;
+use Phalcon\Html\Escaper\EscaperInterface;
+use Phalcon\Html\Exception;
+use Phalcon\Support\Helper\Str\Friendly;
+
+/**
+ * Converts text to a URL-friendly slug.
+ */
+class FriendlyTitle extends AbstractHelper
+{
+    /**
+     * @var Friendly
+     */
+    protected Friendly $friendly;
+
+    /**
+     * @param EscaperInterface $escaper
+     */
+    public function __construct(EscaperInterface $escaper)
+    {
+        parent::__construct($escaper);
+
+        $this->friendly = new Friendly();
+    }
+
+    /**
+     * @param string     $text
+     * @param string     $separator
+     * @param bool       $lowercase
+     * @param mixed|null $replace
+     *
+     * @return string
+     * @throws Exception
+     */
+    public function __invoke(
+        string $text,
+        string $separator = '-',
+        bool $lowercase = true,
+        array|string $replace = []
+    ): string {
+        try {
+            return ($this->friendly)($text, $separator, $lowercase, $replace);
+        } catch (BaseException $ex) {
+            throw new Exception($ex->getMessage());
+        }
+    }
+}

--- a/src/Html/Helper/FriendlyTitle.php
+++ b/src/Html/Helper/FriendlyTitle.php
@@ -13,9 +13,7 @@ declare(strict_types=1);
 
 namespace Phalcon\Html\Helper;
 
-use Exception as BaseException;
 use Phalcon\Html\Escaper\EscaperInterface;
-use Phalcon\Html\Exception;
 use Phalcon\Support\Helper\Str\Friendly;
 
 /**
@@ -39,13 +37,12 @@ class FriendlyTitle extends AbstractHelper
     }
 
     /**
-     * @param string     $text
-     * @param string     $separator
-     * @param bool       $lowercase
-     * @param mixed|null $replace
+     * @param string       $text
+     * @param string       $separator
+     * @param bool         $lowercase
+     * @param array|string $replace
      *
      * @return string
-     * @throws Exception
      */
     public function __invoke(
         string $text,
@@ -53,10 +50,6 @@ class FriendlyTitle extends AbstractHelper
         bool $lowercase = true,
         array|string $replace = []
     ): string {
-        try {
-            return ($this->friendly)($text, $separator, $lowercase, $replace);
-        } catch (BaseException $ex) {
-            throw new Exception($ex->getMessage());
-        }
+        return ($this->friendly)($text, $separator, $lowercase, $replace);
     }
 }

--- a/src/Html/Helper/Input/Select.php
+++ b/src/Html/Helper/Input/Select.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 namespace Phalcon\Html\Helper\Input;
 
 use Phalcon\Html\Helper\AbstractList;
+use Phalcon\Html\Helper\Input\Select\SelectDataInterface;
+use function is_array;
 
 /**
  * Class Select
@@ -99,6 +101,33 @@ class Select extends AbstractList
             ],
             $this->indent(),
         ];
+
+        return $this;
+    }
+
+    /**
+     * Populates the select from a data provider.
+     *
+     * Flat entries: key = option value, value = label string.
+     * Optgroup entries: key = group label, value = [value => label] array.
+     *
+     * @param SelectDataInterface $data
+     *
+     * @return Select
+     */
+    public function fromData(SelectDataInterface $data): Select
+    {
+        foreach ($data->getOptions() as $key => $value) {
+            if (is_array($value)) {
+                $this->optGroup((string) $key);
+                foreach ($value as $subKey => $subValue) {
+                    $this->add((string) $subValue, (string) $subKey);
+                }
+                $this->optGroup((string) $key);
+            } else {
+                $this->add((string) $value, (string) $key);
+            }
+        }
 
         return $this;
     }

--- a/src/Html/Helper/Input/Select.php
+++ b/src/Html/Helper/Input/Select.php
@@ -13,6 +13,7 @@ namespace Phalcon\Html\Helper\Input;
 
 use Phalcon\Html\Helper\AbstractList;
 use Phalcon\Html\Helper\Input\Select\SelectDataInterface;
+
 use function is_array;
 
 /**

--- a/src/Html/Helper/Input/Select/ArrayData.php
+++ b/src/Html/Helper/Input/Select/ArrayData.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Html\Helper\Input\Select;
+
+/**
+ * Wraps a plain PHP array as a SELECT data provider.
+ *
+ * Keys are option values; string values are labels;
+ * array values define optgroups.
+ */
+class ArrayData implements SelectDataInterface
+{
+    /**
+     * @param array $data
+     */
+    public function __construct(
+        protected array $data = []
+    ) {
+    }
+
+    /**
+     * @return array
+     */
+    public function getOptions(): array
+    {
+        return $this->data;
+    }
+}

--- a/src/Html/Helper/Input/Select/ResultsetData.php
+++ b/src/Html/Helper/Input/Select/ResultsetData.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Html\Helper\Input\Select;
+
+use InvalidArgumentException;
+use Phalcon\Mvc\Model\ResultsetInterface;
+
+use function count;
+use function is_array;
+use function is_object;
+use function method_exists;
+
+class ResultsetData implements SelectDataInterface
+{
+    public function __construct(
+        protected ResultsetInterface $resultset,
+        protected array $using
+    ) {
+        if (count($using) !== 2) {
+            throw new InvalidArgumentException(
+                "The 'using' parameter requires exactly two values"
+            );
+        }
+    }
+
+    public function getOptions(): array
+    {
+        [$usingZero, $usingOne] = $this->using;
+        $options = [];
+
+        foreach ($this->resultset as $option) {
+            if (is_object($option)) {
+                if (method_exists($option, 'readAttribute')) {
+                    $optionValue = $option->readAttribute($usingZero);
+                    $optionText  = $option->readAttribute($usingOne);
+                } else {
+                    $optionValue = $option->{$usingZero};
+                    $optionText  = $option->{$usingOne};
+                }
+            } else {
+                if (!is_array($option)) {
+                    throw new InvalidArgumentException(
+                        'Resultset returned an invalid value'
+                    );
+                }
+
+                $optionValue = $option[$usingZero];
+                $optionText  = $option[$usingOne];
+            }
+
+            $options[$optionValue] = $optionText;
+        }
+
+        return $options;
+    }
+}

--- a/src/Html/Helper/Input/Select/SelectDataInterface.php
+++ b/src/Html/Helper/Input/Select/SelectDataInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Html\Helper\Input\Select;
+
+/**
+ * Interface for SELECT option data providers.
+ *
+ * Return format: [value => label] for flat options;
+ * [groupLabel => [value => label, ...]] for optgroups.
+ */
+interface SelectDataInterface
+{
+    public function getOptions(): array;
+}

--- a/src/Html/Helper/Preload.php
+++ b/src/Html/Helper/Preload.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Html\Helper;
+
+use Phalcon\Html\Escaper\EscaperInterface;
+use Phalcon\Html\Link\Link;
+use Phalcon\Html\Link\Serializer\Header;
+use Phalcon\Http\ResponseInterface;
+
+use function array_merge;
+
+/**
+ * Generates a <link rel="preload"> tag for resource hinting.
+ * If a ResponseInterface is provided, also sets the HTTP Link header.
+ */
+class Preload extends AbstractHelper
+{
+    /**
+     * @var ResponseInterface|null
+     */
+    protected ?ResponseInterface $response;
+
+    /**
+     * @param EscaperInterface       $escaper
+     * @param ResponseInterface|null $response
+     */
+    public function __construct(
+        EscaperInterface $escaper,
+        ?ResponseInterface $response = null
+    ) {
+        parent::__construct($escaper);
+
+        $this->response = $response;
+    }
+
+    /**
+     * @param string $href
+     * @param string $type
+     * @param array  $attributes
+     *
+     * @return string
+     */
+    public function __invoke(
+        string $href,
+        string $type = 'style',
+        array $attributes = []
+    ): string {
+        $overrides = [
+            'rel'  => 'preload',
+            'href' => $href,
+            'as'   => $type,
+        ];
+
+        unset($attributes['rel'], $attributes['href'], $attributes['as']);
+
+        $overrides = array_merge($overrides, $attributes);
+
+        if (null !== $this->response) {
+            $link   = new Link('preload', $href, ['as' => $type]);
+            $header = 'Link: ' . (new Header())->serialize([$link]);
+
+            $this->response->setRawHeader($header);
+        }
+
+        return $this->selfClose('link', $overrides);
+    }
+}

--- a/src/Html/TagFactory.php
+++ b/src/Html/TagFactory.php
@@ -84,7 +84,7 @@ use function str_starts_with;
  * @method Doctype       doctype(int $flag, string $delimiter)
  * @method string        element(string $tag, string $text, array $attributes = [], bool $raw = false)
  * @method string        form(array $attributes = [])
- * @method string        friendlyTitle(string $text, string $separator = '-', bool $lowercase = true, array|string $replace = [])
+ * @method string        friendlyTitle(string $text, string $sep = '-', bool $lower = true, array|string $replace = [])
  * @method string        img(string $src, array $attributes = [])
  * @method Checkbox      inputCheckbox(string $name, string $value = null, array $attributes = [])
  * @method Color         inputColor(string $name, string $value = null, array $attributes = [])

--- a/src/Html/TagFactory.php
+++ b/src/Html/TagFactory.php
@@ -22,6 +22,7 @@ use Phalcon\Html\Helper\Close;
 use Phalcon\Html\Helper\Doctype;
 use Phalcon\Html\Helper\Element;
 use Phalcon\Html\Helper\Form;
+use Phalcon\Html\Helper\FriendlyTitle;
 use Phalcon\Html\Helper\Img;
 use Phalcon\Html\Helper\Input\Checkbox;
 use Phalcon\Html\Helper\Input\Color;
@@ -51,10 +52,12 @@ use Phalcon\Html\Helper\Label;
 use Phalcon\Html\Helper\Link;
 use Phalcon\Html\Helper\Meta;
 use Phalcon\Html\Helper\Ol;
+use Phalcon\Html\Helper\Preload;
 use Phalcon\Html\Helper\Script;
 use Phalcon\Html\Helper\Style;
 use Phalcon\Html\Helper\Title;
 use Phalcon\Html\Helper\Ul;
+use Phalcon\Http\ResponseInterface;
 use Phalcon\Traits\Factory\FactoryTrait;
 
 use function call_user_func_array;
@@ -81,6 +84,7 @@ use function str_starts_with;
  * @method Doctype       doctype(int $flag, string $delimiter)
  * @method string        element(string $tag, string $text, array $attributes = [], bool $raw = false)
  * @method string        form(array $attributes = [])
+ * @method string        friendlyTitle(string $text, string $separator = '-', bool $lowercase = true, array|string $replace = [])
  * @method string        img(string $src, array $attributes = [])
  * @method Checkbox      inputCheckbox(string $name, string $value = null, array $attributes = [])
  * @method Color         inputColor(string $name, string $value = null, array $attributes = [])
@@ -110,6 +114,7 @@ use function str_starts_with;
  * @method Link          link(string $indent = '    ', string $delimiter = "\n")
  * @method Meta          meta(string $indent = '    ', string $delimiter = "\n")
  * @method Ol            ol(string $text, array $attributes = [], bool $raw = false)
+ * @method string        preload(string $href, string $type = 'style', array $attributes = [])
  * @method Script        script(string $indent = '    ', string $delimiter = "\n")
  * @method Style         style(string $indent = '    ', string $delimiter = "\n")
  * @method Title         title(string $indent = '    ', string $delimiter = "\n")
@@ -125,14 +130,24 @@ class TagFactory
     private EscaperInterface $escaper;
 
     /**
+     * @var ResponseInterface|null
+     */
+    private ?ResponseInterface $response;
+
+    /**
      * TagFactory constructor.
      *
-     * @param Escaper $escaper
-     * @param array   $services
+     * @param EscaperInterface       $escaper
+     * @param array                  $services
+     * @param ResponseInterface|null $response
      */
-    public function __construct(EscaperInterface $escaper, array $services = [])
-    {
-        $this->escaper = $escaper;
+    public function __construct(
+        EscaperInterface $escaper,
+        array $services = [],
+        ?ResponseInterface $response = null
+    ) {
+        $this->escaper  = $escaper;
+        $this->response = $response;
 
         $this->init($services);
     }
@@ -186,6 +201,10 @@ class TagFactory
             return $this->getCachedInstance($name, $this->escaper, $doctype);
         }
 
+        if ($name === 'preload') {
+            return $this->getCachedInstance($name, $this->escaper, $this->response);
+        }
+
         return $this->getCachedInstance($name, $this->escaper);
     }
 
@@ -224,6 +243,7 @@ class TagFactory
             'doctype'            => Doctype::class,
             'element'            => Element::class,
             'form'               => Form::class,
+            'friendlyTitle'      => FriendlyTitle::class,
             'img'                => Img::class,
             'inputCheckbox'      => Checkbox::class,
             'inputColor'         => Color::class,
@@ -253,6 +273,7 @@ class TagFactory
             'link'               => Link::class,
             'meta'               => Meta::class,
             'ol'                 => Ol::class,
+            'preload'            => Preload::class,
             'script'             => Script::class,
             'style'              => Style::class,
             'title'              => Title::class,

--- a/tests/unit/Forms/Element/GetSetTagFactoryTest.php
+++ b/tests/unit/Forms/Element/GetSetTagFactoryTest.php
@@ -15,6 +15,7 @@ namespace Phalcon\Tests\Unit\Forms\Element;
 
 use Phalcon\Di\Di;
 use Phalcon\Forms\Element\Text;
+use Phalcon\Forms\Exception;
 use Phalcon\Forms\Form;
 use Phalcon\Html\Escaper;
 use Phalcon\Html\TagFactory;
@@ -123,22 +124,15 @@ final class GetSetTagFactoryTest extends AbstractUnitTestCase
      * @author Phalcon Team <team@phalcon.io>
      * @since  2024-01-01
      */
-    public function testFormsElementGetLocalTagFactoryDiFallbackNoTagService(): void
+    public function testFormsElementGetLocalTagFactoryThrowsWhenNotResolvable(): void
     {
-        $escaper = new Escaper();
-        $di      = new Di();
-        $di->setShared('escaper', $escaper);
-        // Deliberately no 'tag' service
-        Di::setDefault($di);
+        Di::reset();
 
         $name    = uniqid();
         $element = new Text($name);
 
-        // render() calls getLocalTagFactory() which falls through to L603-609
-        $expected = sprintf('<input type="text" id="%s" name="%s">', $name, $name);
-        $actual   = $element->render();
-        $this->assertSame($expected, $actual);
+        $this->expectException(Exception::class);
 
-        Di::reset();
+        $element->render();
     }
 }

--- a/tests/unit/Forms/Element/Select/RenderTest.php
+++ b/tests/unit/Forms/Element/Select/RenderTest.php
@@ -5,7 +5,7 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
+ * For the full copyright and license information, please view the LICENSE.md
  * file that was distributed with this source code.
  */
 
@@ -13,19 +13,109 @@ declare(strict_types=1);
 
 namespace Phalcon\Tests\Unit\Forms\Element\Select;
 
+use Phalcon\Forms\Element\Select;
+use Phalcon\Html\Escaper;
+use Phalcon\Html\TagFactory;
 use Phalcon\Tests\AbstractUnitTestCase;
 
-/**
- * Class RenderTest extends AbstractUnitTestCase
- */
+use function preg_replace;
+
 final class RenderTest extends AbstractUnitTestCase
 {
-    /**
-     * @author Phalcon Team <team@phalcon.io>
-     * @since  2018-11-13
-     */
-    public function testFormsElementSelectRender(): void
+    private function normalize(string $html): string
     {
-        $this->markTestSkipped('Need implementation');
+        return preg_replace('/[[:cntrl:]]/', '', $html);
+    }
+
+    /** @author Phalcon Team <team@phalcon.io> @since 2026-04-17 */
+    public function testRenderFlatOptions(): void
+    {
+        $element = new Select('status', ['1' => 'Active', '2' => 'Inactive']);
+        $element->setTagFactory(new TagFactory(new Escaper()));
+
+        $actual = $this->normalize($element->render());
+
+        $this->assertSame(
+            '<select id="status" name="status">'
+            . '<option value="1">Active</option>'
+            . '<option value="2">Inactive</option>'
+            . '</select>',
+            $actual
+        );
+    }
+
+    /** @author Phalcon Team <team@phalcon.io> @since 2026-04-17 */
+    public function testRenderWithSelectedValue(): void
+    {
+        $element = new Select('status', ['1' => 'Active', '2' => 'Inactive']);
+        $element->setTagFactory(new TagFactory(new Escaper()));
+        $element->setDefault('2');
+
+        $actual = $element->render();
+
+        $this->assertStringContainsString('selected="selected"', $actual);
+        $this->assertStringContainsString('value="2"', $actual);
+    }
+
+    /** @author Phalcon Team <team@phalcon.io> @since 2026-04-17 */
+    public function testRenderWithUseEmpty(): void
+    {
+        $element = new Select(
+            'status',
+            ['1' => 'Active'],
+            [
+                'useEmpty'   => true,
+                'emptyValue' => '',
+                'emptyText'  => 'Pick one',
+            ]
+        );
+        $element->setTagFactory(new TagFactory(new Escaper()));
+
+        $actual = $this->normalize($element->render());
+
+        $this->assertStringContainsString('<option value="">Pick one</option>', $actual);
+    }
+
+    /** @author Phalcon Team <team@phalcon.io> @since 2026-04-17 */
+    public function testRenderWithOptgroups(): void
+    {
+        $element = new Select(
+            'cars',
+            [
+                'Italian'  => ['1' => 'Ferrari'],
+                'American' => ['2' => 'Ford'],
+            ]
+        );
+        $element->setTagFactory(new TagFactory(new Escaper()));
+
+        $actual = $element->render();
+
+        $this->assertStringContainsString('<optgroup', $actual);
+        $this->assertStringContainsString('label="Italian"', $actual);
+        $this->assertStringContainsString('label="American"', $actual);
+    }
+
+    /** @author Phalcon Team <team@phalcon.io> @since 2026-04-17 */
+    public function testRenderWithExtraAttributes(): void
+    {
+        $element = new Select('status', ['1' => 'Active']);
+        $element->setTagFactory(new TagFactory(new Escaper()));
+
+        $actual = $this->normalize($element->render(['class' => 'form-select']));
+
+        $this->assertStringContainsString('class="form-select"', $actual);
+        $this->assertStringContainsString('id="status"', $actual);
+        $this->assertStringContainsString('name="status"', $actual);
+    }
+
+    /** @author Phalcon Team <team@phalcon.io> @since 2026-04-17 */
+    public function testRenderReturnsWrapperWhenNoOptions(): void
+    {
+        $element = new Select('status');
+        $element->setTagFactory(new TagFactory(new Escaper()));
+
+        $actual = $this->normalize($element->render());
+
+        $this->assertSame('<select id="status" name="status"></select>', $actual);
     }
 }

--- a/tests/unit/Html/Helper/FriendlyTitle/UnderscoreInvokeTest.php
+++ b/tests/unit/Html/Helper/FriendlyTitle/UnderscoreInvokeTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Html\Helper\FriendlyTitle;
+
+use Phalcon\Html\Escaper;
+use Phalcon\Html\Helper\FriendlyTitle;
+use Phalcon\Html\TagFactory;
+use Phalcon\Tests\AbstractUnitTestCase;
+
+final class UnderscoreInvokeTest extends AbstractUnitTestCase
+{
+    /**
+     * @return array<array<mixed>>
+     */
+    public static function getExamples(): array
+    {
+        return [
+            [
+                'hello-world',
+                'Hello World',
+                '-',
+                true,
+                [],
+            ],
+            [
+                'Hello-World',
+                'Hello World',
+                '-',
+                false,
+                [],
+            ],
+            [
+                'hello_world',
+                'Hello World',
+                '_',
+                true,
+                [],
+            ],
+            [
+                'hello-and-world',
+                'Hello & World',
+                '-',
+                true,
+                [],
+            ],
+            [
+                'hello-world',
+                'Héllo Wörld',
+                '-',
+                true,
+                [],
+            ],
+            [
+                'hello-world',
+                'Hello/World',
+                '-',
+                true,
+                ['/'],
+            ],
+            [
+                'hello-world',
+                'Hello.World',
+                '-',
+                true,
+                '.',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider getExamples
+     *
+     * @author       Phalcon Team <team@phalcon.io>
+     * @since        2026-04-17
+     */
+    public function testHtmlHelperFriendlyTitleUnderscoreInvoke(
+        string $expected,
+        string $text,
+        string $separator,
+        bool $lowercase,
+        array|string $replace
+    ): void {
+        $escaper = new Escaper();
+        $helper  = new FriendlyTitle($escaper);
+
+        $actual = $helper($text, $separator, $lowercase, $replace);
+        $this->assertSame($expected, $actual);
+
+        $factory = new TagFactory($escaper);
+        $locator = $factory->newInstance('friendlyTitle');
+        $actual  = $locator($text, $separator, $lowercase, $replace);
+        $this->assertSame($expected, $actual);
+
+        $factory = new TagFactory($escaper);
+        $actual  = $factory->friendlyTitle($text, $separator, $lowercase, $replace);
+        $this->assertSame($expected, $actual);
+    }
+}

--- a/tests/unit/Html/Helper/Input/Select/ArrayDataTest.php
+++ b/tests/unit/Html/Helper/Input/Select/ArrayDataTest.php
@@ -3,6 +3,8 @@
 /**
  * This file is part of the Phalcon Framework.
  *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
  * For the full copyright and license information, please view the LICENSE.md
  * file that was distributed with this source code.
  */
@@ -22,8 +24,10 @@ final class ArrayDataTest extends AbstractUnitTestCase
      */
     public function testGetOptionsReturnsFlatArray(): void
     {
-        $arrayData = new ArrayData(['1' => 'Ferrari', '2' => 'Ford']);
-        $this->assertSame(['1' => 'Ferrari', '2' => 'Ford'], $arrayData->getOptions());
+        $data = new ArrayData(['1' => 'Ferrari', '2' => 'Ford']);
+        $expected = ['1' => 'Ferrari', '2' => 'Ford'];
+        $actual = $data->getOptions();
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -34,10 +38,11 @@ final class ArrayDataTest extends AbstractUnitTestCase
     {
         $input = [
             'Group A' => ['1' => 'Ferrari', '2' => 'Ford'],
-            '3' => 'Toyota',
+            '3' => 'Toyota'
         ];
-        $arrayData = new ArrayData($input);
-        $this->assertSame($input, $arrayData->getOptions());
+        $data = new ArrayData($input);
+        $actual = $data->getOptions();
+        $this->assertSame($input, $actual);
     }
 
     /**
@@ -46,7 +51,9 @@ final class ArrayDataTest extends AbstractUnitTestCase
      */
     public function testGetOptionsReturnsEmptyArrayWhenNoData(): void
     {
-        $arrayData = new ArrayData();
-        $this->assertSame([], $arrayData->getOptions());
+        $data = new ArrayData();
+        $expected = [];
+        $actual = $data->getOptions();
+        $this->assertSame($expected, $actual);
     }
 }

--- a/tests/unit/Html/Helper/Input/Select/ArrayDataTest.php
+++ b/tests/unit/Html/Helper/Input/Select/ArrayDataTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Html\Helper\Input\Select;
+
+use Phalcon\Html\Helper\Input\Select\ArrayData;
+use Phalcon\Tests\AbstractUnitTestCase;
+
+final class ArrayDataTest extends AbstractUnitTestCase
+{
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-17
+     */
+    public function testGetOptionsReturnsFlatArray(): void
+    {
+        $arrayData = new ArrayData(['1' => 'Ferrari', '2' => 'Ford']);
+        $this->assertSame(['1' => 'Ferrari', '2' => 'Ford'], $arrayData->getOptions());
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-17
+     */
+    public function testGetOptionsReturnsNestedArrayForOptgroups(): void
+    {
+        $input = [
+            'Group A' => ['1' => 'Ferrari', '2' => 'Ford'],
+            '3' => 'Toyota',
+        ];
+        $arrayData = new ArrayData($input);
+        $this->assertSame($input, $arrayData->getOptions());
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-17
+     */
+    public function testGetOptionsReturnsEmptyArrayWhenNoData(): void
+    {
+        $arrayData = new ArrayData();
+        $this->assertSame([], $arrayData->getOptions());
+    }
+}

--- a/tests/unit/Html/Helper/Input/Select/Fake/FakeResultset.php
+++ b/tests/unit/Html/Helper/Input/Select/Fake/FakeResultset.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Html\Helper\Input\Select\Fake;
+
+use ArrayIterator;
+use Closure;
+use Phalcon\Mvc\Model\ResultsetInterface;
+use Phalcon\Mvc\ModelInterface;
+
+final class FakeResultset extends ArrayIterator implements ResultsetInterface
+{
+    public function delete(Closure | null $conditionCallback = null): bool
+    {
+        return false;
+    }
+
+    public function filter(callable $filter): array
+    {
+        return [];
+    }
+
+    public function getCache(): mixed
+    {
+        return null;
+    }
+
+    public function getFirst(): mixed
+    {
+        return null;
+    }
+
+    public function getHydrateMode(): int
+    {
+        return 0;
+    }
+
+    public function getLast(): ModelInterface | null
+    {
+        return null;
+    }
+
+    public function getMessages(): array
+    {
+        return [];
+    }
+
+    public function getType(): int
+    {
+        return 0;
+    }
+
+    public function isFresh(): bool
+    {
+        return false;
+    }
+
+    public function setHydrateMode(int $hydrateMode): ResultsetInterface
+    {
+        return $this;
+    }
+
+    public function setIsFresh(bool $isFresh): ResultsetInterface
+    {
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return iterator_to_array($this);
+    }
+
+    public function update(mixed $data, Closure | null $conditionCallback = null): bool
+    {
+        return false;
+    }
+}

--- a/tests/unit/Html/Helper/Input/Select/ResultsetDataTest.php
+++ b/tests/unit/Html/Helper/Input/Select/ResultsetDataTest.php
@@ -13,15 +13,10 @@ declare(strict_types=1);
 
 namespace Phalcon\Tests\Unit\Html\Helper\Input\Select;
 
-use ArrayIterator;
-use BadMethodCallException;
-use Closure;
 use InvalidArgumentException;
 use Phalcon\Html\Helper\Input\Select\ResultsetData;
-use Phalcon\Messages\MessageInterface;
-use Phalcon\Mvc\Model\ResultsetInterface;
-use Phalcon\Mvc\ModelInterface;
 use Phalcon\Tests\AbstractUnitTestCase;
+use Phalcon\Tests\Unit\Html\Helper\Input\Select\Fake\FakeResultset;
 
 final class ResultsetDataTest extends AbstractUnitTestCase
 {
@@ -34,10 +29,7 @@ final class ResultsetDataTest extends AbstractUnitTestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('requires exactly two values');
 
-        new ResultsetData(
-            $this->buildResultsetMock([]),
-            ['id']
-        );
+        new ResultsetData(new FakeResultset([]), ['id']);
     }
 
     /**
@@ -46,8 +38,7 @@ final class ResultsetDataTest extends AbstractUnitTestCase
      */
     public function testGetOptionsReturnsEmptyArrayForEmptyResultset(): void
     {
-        $resultset = $this->buildResultsetMock([]);
-        $data      = new ResultsetData($resultset, ['id', 'name']);
+        $data = new ResultsetData(new FakeResultset([]), ['id', 'name']);
 
         $this->assertSame([], $data->getOptions());
     }
@@ -63,10 +54,9 @@ final class ResultsetDataTest extends AbstractUnitTestCase
             ['id' => '2', 'name' => 'Ford'],
         ];
 
-        $resultset = $this->buildResultsetMock($rows);
-        $data      = new ResultsetData($resultset, ['id', 'name']);
-
+        $data     = new ResultsetData(new FakeResultset($rows), ['id', 'name']);
         $expected = ['1' => 'Ferrari', '2' => 'Ford'];
+
         $this->assertSame($expected, $data->getOptions());
     }
 
@@ -88,93 +78,9 @@ final class ResultsetDataTest extends AbstractUnitTestCase
         $row2->method('readAttribute')
              ->willReturnMap([['id', '2'], ['name', 'Ford']]);
 
-        $resultset = $this->buildResultsetMock([$row1, $row2]);
-
-        $data   = new ResultsetData($resultset, ['id', 'name']);
+        $data   = new ResultsetData(new FakeResultset([$row1, $row2]), ['id', 'name']);
         $actual = $data->getOptions();
 
         $this->assertSame(['1' => 'Ferrari', '2' => 'Ford'], $actual);
-    }
-
-    /**
-     * @param array $rows
-     *
-     * @return ResultsetInterface
-     */
-    private function buildResultsetMock(array $rows): ResultsetInterface
-    {
-        return new class ($rows) extends ArrayIterator implements ResultsetInterface {
-            public function __construct(array $rows)
-            {
-                parent::__construct($rows);
-            }
-
-            public function delete(Closure | null $conditionCallback = null): bool
-            {
-                throw new BadMethodCallException('Not implemented');
-            }
-
-            public function filter(callable $filter): array
-            {
-                throw new BadMethodCallException('Not implemented');
-            }
-
-            public function getCache(): mixed
-            {
-                throw new BadMethodCallException('Not implemented');
-            }
-
-            public function getFirst(): mixed
-            {
-                throw new BadMethodCallException('Not implemented');
-            }
-
-            public function getHydrateMode(): int
-            {
-                throw new BadMethodCallException('Not implemented');
-            }
-
-            public function getLast(): ModelInterface | null
-            {
-                throw new BadMethodCallException('Not implemented');
-            }
-
-            public function getMessages(): array
-            {
-                throw new BadMethodCallException('Not implemented');
-            }
-
-            public function getType(): int
-            {
-                throw new BadMethodCallException('Not implemented');
-            }
-
-            public function isFresh(): bool
-            {
-                throw new BadMethodCallException('Not implemented');
-            }
-
-            public function setHydrateMode(int $hydrateMode): ResultsetInterface
-            {
-                throw new BadMethodCallException('Not implemented');
-            }
-
-            public function setIsFresh(bool $isFresh): ResultsetInterface
-            {
-                throw new BadMethodCallException('Not implemented');
-            }
-
-            public function toArray(): array
-            {
-                throw new BadMethodCallException('Not implemented');
-            }
-
-            public function update(
-                mixed $data,
-                Closure | null $conditionCallback = null
-            ): bool {
-                throw new BadMethodCallException('Not implemented');
-            }
-        };
     }
 }

--- a/tests/unit/Html/Helper/Input/Select/ResultsetDataTest.php
+++ b/tests/unit/Html/Helper/Input/Select/ResultsetDataTest.php
@@ -1,0 +1,180 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Html\Helper\Input\Select;
+
+use ArrayIterator;
+use BadMethodCallException;
+use Closure;
+use InvalidArgumentException;
+use Phalcon\Html\Helper\Input\Select\ResultsetData;
+use Phalcon\Messages\MessageInterface;
+use Phalcon\Mvc\Model\ResultsetInterface;
+use Phalcon\Mvc\ModelInterface;
+use Phalcon\Tests\AbstractUnitTestCase;
+
+final class ResultsetDataTest extends AbstractUnitTestCase
+{
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-17
+     */
+    public function testConstructorThrowsOnInvalidUsingCount(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('requires exactly two values');
+
+        new ResultsetData(
+            $this->buildResultsetMock([]),
+            ['id']
+        );
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-17
+     */
+    public function testGetOptionsReturnsEmptyArrayForEmptyResultset(): void
+    {
+        $resultset = $this->buildResultsetMock([]);
+        $data      = new ResultsetData($resultset, ['id', 'name']);
+
+        $this->assertSame([], $data->getOptions());
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-17
+     */
+    public function testGetOptionsReturnsValueLabelPairsFromArrayRows(): void
+    {
+        $rows = [
+            ['id' => '1', 'name' => 'Ferrari'],
+            ['id' => '2', 'name' => 'Ford'],
+        ];
+
+        $resultset = $this->buildResultsetMock($rows);
+        $data      = new ResultsetData($resultset, ['id', 'name']);
+
+        $expected = ['1' => 'Ferrari', '2' => 'Ford'];
+        $this->assertSame($expected, $data->getOptions());
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-17
+     */
+    public function testGetOptionsReturnsValueLabelPairsFromObjects(): void
+    {
+        $row1 = $this->getMockBuilder(\stdClass::class)
+                     ->addMethods(['readAttribute'])
+                     ->getMock();
+        $row1->method('readAttribute')
+             ->willReturnMap([['id', '1'], ['name', 'Ferrari']]);
+
+        $row2 = $this->getMockBuilder(\stdClass::class)
+                     ->addMethods(['readAttribute'])
+                     ->getMock();
+        $row2->method('readAttribute')
+             ->willReturnMap([['id', '2'], ['name', 'Ford']]);
+
+        $resultset = $this->buildResultsetMock([$row1, $row2]);
+
+        $data   = new ResultsetData($resultset, ['id', 'name']);
+        $actual = $data->getOptions();
+
+        $this->assertSame(['1' => 'Ferrari', '2' => 'Ford'], $actual);
+    }
+
+    /**
+     * @param array $rows
+     *
+     * @return ResultsetInterface
+     */
+    private function buildResultsetMock(array $rows): ResultsetInterface
+    {
+        return new class ($rows) extends ArrayIterator implements ResultsetInterface {
+            public function __construct(array $rows)
+            {
+                parent::__construct($rows);
+            }
+
+            public function delete(Closure | null $conditionCallback = null): bool
+            {
+                throw new BadMethodCallException('Not implemented');
+            }
+
+            public function filter(callable $filter): array
+            {
+                throw new BadMethodCallException('Not implemented');
+            }
+
+            public function getCache(): mixed
+            {
+                throw new BadMethodCallException('Not implemented');
+            }
+
+            public function getFirst(): mixed
+            {
+                throw new BadMethodCallException('Not implemented');
+            }
+
+            public function getHydrateMode(): int
+            {
+                throw new BadMethodCallException('Not implemented');
+            }
+
+            public function getLast(): ModelInterface | null
+            {
+                throw new BadMethodCallException('Not implemented');
+            }
+
+            public function getMessages(): array
+            {
+                throw new BadMethodCallException('Not implemented');
+            }
+
+            public function getType(): int
+            {
+                throw new BadMethodCallException('Not implemented');
+            }
+
+            public function isFresh(): bool
+            {
+                throw new BadMethodCallException('Not implemented');
+            }
+
+            public function setHydrateMode(int $hydrateMode): ResultsetInterface
+            {
+                throw new BadMethodCallException('Not implemented');
+            }
+
+            public function setIsFresh(bool $isFresh): ResultsetInterface
+            {
+                throw new BadMethodCallException('Not implemented');
+            }
+
+            public function toArray(): array
+            {
+                throw new BadMethodCallException('Not implemented');
+            }
+
+            public function update(
+                mixed $data,
+                Closure | null $conditionCallback = null
+            ): bool {
+                throw new BadMethodCallException('Not implemented');
+            }
+        };
+    }
+}

--- a/tests/unit/Html/Helper/Input/SelectFromDataTest.php
+++ b/tests/unit/Html/Helper/Input/SelectFromDataTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Html\Helper\Input;
+
+use Phalcon\Html\Escaper;
+use Phalcon\Html\Helper\Input\Select;
+use Phalcon\Html\Helper\Input\Select\ArrayData;
+use Phalcon\Tests\AbstractUnitTestCase;
+
+use const PHP_EOL;
+
+final class SelectFromDataTest extends AbstractUnitTestCase
+{
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-17
+     */
+    public function testFromDataRendersFlatOptions(): void
+    {
+        $escaper = new Escaper();
+        $helper  = new Select($escaper);
+        $result  = $helper('    ', PHP_EOL, ['id' => 'cars']);
+        $result->fromData(new ArrayData(['1' => 'Ferrari', '2' => 'Ford']));
+
+        $expected = '<select id="cars">' . PHP_EOL
+            . '    <option value="1">Ferrari</option>' . PHP_EOL
+            . '    <option value="2">Ford</option>' . PHP_EOL
+            . '</select>';
+
+        $this->assertSame($expected, (string) $result);
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-17
+     */
+    public function testFromDataRendersOptgroups(): void
+    {
+        $escaper = new Escaper();
+        $helper  = new Select($escaper);
+        $result  = $helper('    ', PHP_EOL, ['id' => 'cars']);
+        $result->fromData(new ArrayData([
+            'Italian'  => ['1' => 'Ferrari'],
+            'American' => ['2' => 'Ford'],
+        ]));
+
+        $expected = '<select id="cars">' . PHP_EOL
+            . '    <optgroup label="Italian">' . PHP_EOL
+            . '        <option value="1">Ferrari</option>' . PHP_EOL
+            . '    </optgroup>' . PHP_EOL
+            . '    <optgroup label="American">' . PHP_EOL
+            . '        <option value="2">Ford</option>' . PHP_EOL
+            . '    </optgroup>' . PHP_EOL
+            . '</select>';
+
+        $this->assertSame($expected, (string) $result);
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-17
+     */
+    public function testFromDataRespectsSelectedValue(): void
+    {
+        $escaper = new Escaper();
+        $helper  = new Select($escaper);
+        $result  = $helper('    ', PHP_EOL, ['id' => 'cars']);
+        $result->selected('2');
+        $result->fromData(new ArrayData(['1' => 'Ferrari', '2' => 'Ford']));
+
+        $actual = (string) $result;
+
+        $this->assertStringContainsString('selected="selected"', $actual);
+        $this->assertStringContainsString('value="2"', $actual);
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-17
+     */
+    public function testFromDataWithEmptyArrayRendersEmptySelect(): void
+    {
+        $escaper = new Escaper();
+        $helper  = new Select($escaper);
+        $result  = $helper('    ', PHP_EOL, ['id' => 'cars']);
+        $result->fromData(new ArrayData([]));
+
+        $this->assertSame('', (string) $result);
+    }
+}

--- a/tests/unit/Html/Helper/Preload/UnderscoreInvokeTest.php
+++ b/tests/unit/Html/Helper/Preload/UnderscoreInvokeTest.php
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Html\Helper\Preload;
+
+use Phalcon\Html\Escaper;
+use Phalcon\Html\Helper\Preload;
+use Phalcon\Html\TagFactory;
+use Phalcon\Http\ResponseInterface;
+use Phalcon\Tests\AbstractUnitTestCase;
+
+final class UnderscoreInvokeTest extends AbstractUnitTestCase
+{
+    /**
+     * @return array<array<mixed>>
+     */
+    public static function getExamples(): array
+    {
+        return [
+            [
+                '<link rel="preload" href="/my-style.css" as="style" />',
+                '/my-style.css',
+                'style',
+                [],
+            ],
+            [
+                '<link rel="preload" href="/my-script.js" as="script" />',
+                '/my-script.js',
+                'script',
+                [],
+            ],
+            [
+                '<link rel="preload" href="/my-font.woff2" as="font" />',
+                '/my-font.woff2',
+                'font',
+                [],
+            ],
+            [
+                '<link rel="preload" href="/my-style.css" as="style" crossorigin="anonymous" />',
+                '/my-style.css',
+                'style',
+                ['crossorigin' => 'anonymous'],
+            ],
+            [
+                '<link rel="preload" href="/my-style.css" as="style" />',
+                '/my-style.css',
+                'style',
+                ['rel' => 'stylesheet', 'href' => '/other.css', 'as' => 'font'],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider getExamples
+     *
+     * @author       Phalcon Team <team@phalcon.io>
+     * @since        2026-04-17
+     */
+    public function testHtmlHelperPreloadUnderscoreInvoke(
+        string $expected,
+        string $href,
+        string $type,
+        array $attributes
+    ): void {
+        $escaper = new Escaper();
+        $helper  = new Preload($escaper);
+
+        $actual = $helper($href, $type, $attributes);
+        $this->assertSame($expected, $actual);
+
+        $factory = new TagFactory($escaper);
+        $locator = $factory->newInstance('preload');
+        $actual  = $locator($href, $type, $attributes);
+        $this->assertSame($expected, $actual);
+
+        $factory = new TagFactory($escaper);
+        $actual  = $factory->preload($href, $type, $attributes);
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-17
+     */
+    public function testHtmlHelperPreloadSetsResponseHeader(): void
+    {
+        $escaper  = new Escaper();
+        $response = $this->createMock(ResponseInterface::class);
+
+        $response
+            ->expects($this->once())
+            ->method('setRawHeader')
+            ->with('Link: </my-font.woff2>; rel="preload"; as="font"')
+        ;
+
+        $helper = new Preload($escaper, $response);
+        $actual = $helper('/my-font.woff2', 'font');
+
+        $this->assertSame('<link rel="preload" href="/my-font.woff2" as="font" />', $actual);
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-17
+     */
+    public function testHtmlHelperPreloadSetsResponseHeaderViaTagFactory(): void
+    {
+        $escaper  = new Escaper();
+        $response = $this->createMock(ResponseInterface::class);
+
+        $response
+            ->expects($this->once())
+            ->method('setRawHeader')
+            ->with('Link: </my-style.css>; rel="preload"; as="style"')
+        ;
+
+        $factory = new TagFactory($escaper, [], $response);
+        $actual  = $factory->preload('/my-style.css', 'style');
+
+        $this->assertSame('<link rel="preload" href="/my-style.css" as="style" />', $actual);
+    }
+}


### PR DESCRIPTION
Replaces the deprecated `Phalcon\Tag\Select` usage in `Forms\Element\Select::render()` with the `TagFactory`-based `Html\Helper\Input\Select` helper.

Changes:

- Introduces a `SelectDataInterface` with two concrete implementations - `ArrayData` (wraps a plain PHP array) and `ResultsetData` (wraps a `ResultsetInterface` with a two-column using  map) - keeping ORM concerns out of the HTML helper.
- Adds `Html\Helper\Input\Select::fromData()` which iterates the data provider and delegates to existing `add()` / `optGroup()` methods, with full optgroup support for nested arrays.  
- Rewrites `Forms\Element\Select::render()` to use the new helper, preserving all existing behavior: selected value, `useEmpty`/`emptyValue`/`emptyText`, using for resultsets, `id`/`name` attribute handling, and bracket-name detection.                                                                                                                                   
- Moves exception messages out of throw sites into named static factory methods on Forms\Exception (`usingParameterRequired`, `tagFactoryNotFound`).
- Removes the silent last-resort DI fallback in `AbstractElement::getLocalTagFactory()` that constructed a fresh `TagFactory` from scratch; an explicit exception is now thrown when  neither `setTagFactory()` nor the parent Form provides one, with a null guard for environments where no DI container is registered.