### PR TITLE
T742 adjusting interfaces to use container

### DIFF
--- a/resources/docker/develop/Dockerfile
+++ b/resources/docker/develop/Dockerfile
@@ -96,13 +96,7 @@ RUN set -eux \
     && rm -rf /tmp/* /var/tmp/* \
     && find /var/cache/apt/archives /var/lib/apt/lists -not -name lock -type f -delete \
     && find /var/cache -type f -delete \
-    && find /var/log -type f -delete \
-# Setup the phalcon-module \
-    && cd /tmp \
-    && git clone https://github.com/niden/phalcon-module \
-    && cd phalcon-module/ext \
-    && ./install \
-    && echo "extension=phalcon" > /usr/local/etc/php/conf.d/phalcon.ini
+    && find /var/log -type f -delete
 
 # hadolint ignore=DL3022
 COPY --from=composer/composer:2 --chown=${USER}:${GROUP} --chmod=0770 /usr/bin/composer /usr/bin/composer

--- a/src/Application/AbstractApplication.php
+++ b/src/Application/AbstractApplication.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Phalcon\Application;
 
+use Phalcon\Container\Service\Collection;
 use Phalcon\Di\DiInterface;
 use Phalcon\Di\Injectable;
 use Phalcon\Events\EventsAwareInterface;
@@ -46,9 +47,9 @@ abstract class AbstractApplication extends Injectable implements EventsAwareInte
     /**
      * AbstractApplication constructor.
      *
-     * @param DiInterface|null $container
+     * @param DiInterface|Collection|null $container
      */
-    public function __construct(DiInterface | null $container = null)
+    public function __construct(DiInterface | Collection | null $container = null)
     {
         $this->container = $container;
     }

--- a/src/Cli/Console.php
+++ b/src/Cli/Console.php
@@ -67,7 +67,7 @@ class Console extends AbstractApplication
         }
 
         /** @var Router $router */
-        $router = $this->container->getShared("router");
+        $router = $this->container->get("router");
 
         if (empty($arguments) && !empty($this->arguments)) {
             $router->handle($this->arguments);
@@ -127,7 +127,7 @@ class Console extends AbstractApplication
         }
 
         /** @var Dispatcher $dispatcher */
-        $dispatcher = $this->container->getShared("dispatcher");
+        $dispatcher = $this->container->get("dispatcher");
 
         $dispatcher->setModuleName($router->getModuleName());
         $dispatcher->setTaskName($router->getTaskName());

--- a/src/Cli/Console.php
+++ b/src/Cli/Console.php
@@ -16,6 +16,7 @@ namespace Phalcon\Cli;
 use Phalcon\Application\AbstractApplication;
 use Phalcon\Cli\Console\Exception;
 use Phalcon\Cli\Router\Route;
+use Phalcon\Di\DiInterface;
 use Phalcon\Events\Exception as EventsException;
 
 use function array_merge;
@@ -67,7 +68,11 @@ class Console extends AbstractApplication
         }
 
         /** @var Router $router */
-        $router = $this->container->get("router");
+        if ($this->container instanceof DiInterface) {
+            $router = $this->container->getShared("router");
+        } else {
+            $router = $this->container->get("router");
+        }
 
         if (empty($arguments) && !empty($this->arguments)) {
             $router->handle($this->arguments);
@@ -127,7 +132,11 @@ class Console extends AbstractApplication
         }
 
         /** @var Dispatcher $dispatcher */
-        $dispatcher = $this->container->get("dispatcher");
+        if ($this->container instanceof DiInterface) {
+            $dispatcher = $this->container->getShared("dispatcher");
+        } else {
+            $dispatcher = $this->container->get("dispatcher");
+        }
 
         $dispatcher->setModuleName($router->getModuleName());
         $dispatcher->setTaskName($router->getTaskName());

--- a/src/Cli/Dispatcher.php
+++ b/src/Cli/Dispatcher.php
@@ -15,6 +15,7 @@ namespace Phalcon\Cli;
 
 use Exception;
 use Phalcon\Cli\Dispatcher\Exception as DispatcherException;
+use Phalcon\Di\DiInterface;
 use Phalcon\Dispatcher\AbstractDispatcher as CliDispatcher;
 use Phalcon\Filter\Exception as FilterException;
 use Phalcon\Filter\Filter;
@@ -142,7 +143,11 @@ class Dispatcher extends CliDispatcher implements DispatcherInterface
         );
 
         /** @var Filter $filter */
-        $filter = $this->container->get("filter");
+        if ($this->container instanceof DiInterface) {
+            $filter = $this->container->getShared("filter");
+        } else {
+            $filter = $this->container->get("filter");
+        }
 
         return $filter->sanitize($optionValue, $filters);
     }

--- a/src/Cli/Dispatcher.php
+++ b/src/Cli/Dispatcher.php
@@ -142,7 +142,7 @@ class Dispatcher extends CliDispatcher implements DispatcherInterface
         );
 
         /** @var Filter $filter */
-        $filter = $this->container->getShared("filter");
+        $filter = $this->container->get("filter");
 
         return $filter->sanitize($optionValue, $filters);
     }

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -49,6 +49,8 @@ use Phalcon\Container\Resolver\Resolver;
 use Phalcon\Container\Service\Collection;
 use Phalcon\Di\InjectionAwareInterface;
 
+use ReflectionException;
+
 use function array_key_exists;
 use function class_exists;
 use function in_array;
@@ -56,15 +58,36 @@ use function is_object;
 
 class Container implements Collection
 {
-    protected array $aliases           = [];
-    protected bool $autowire           = true;
+    /**
+     * @var array<string, string>
+     */
+    protected array $aliases = [];
+    protected bool $autowire = true;
+    /**
+     * @var array<string, string>
+     */
     protected array $instanceLifetimes = [];
-    protected array $instances         = [];
-    protected array $parameters        = [];
-    protected array $processors        = [];
+    /**
+     * @var array<string, object>
+     */
+    protected array $instances = [];
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $parameters = [];
+    /**
+     * @var array<string, Processor>
+     */
+    protected array $processors = [];
     protected Resolver $resolver;
-    protected array $services          = [];
-    protected array $tags              = [];
+    /**
+     * @var array<string, ServiceDefinition>
+     */
+    protected array $services = [];
+    /**
+     * @var array<string, list<string>>
+     */
+    protected array $tags = [];
 
     public function __construct()
     {
@@ -76,11 +99,26 @@ class Container implements Collection
         ];
     }
 
+    /**
+     * Bind an interface to a concrete class
+     *
+     * @param string $interface
+     * @param string $concrete
+     *
+     * @return ServiceDefinition
+     */
     public function bind(string $interface, string $concrete): ServiceDefinition
     {
         return $this->set($interface, $concrete);
     }
 
+    /**
+     * Resolve to a closure on a get()
+     *
+     * @param string $name
+     *
+     * @return Closure
+     */
     public function callableGet(string $name): Closure
     {
         return function () use ($name) {
@@ -88,6 +126,12 @@ class Container implements Collection
         };
     }
 
+    /**
+     * Resolve to a closure on a new()
+     * @param string $name
+     *
+     * @return Closure
+     */
     public function callableNew(string $name): Closure
     {
         return function () use ($name) {
@@ -95,6 +139,16 @@ class Container implements Collection
         };
     }
 
+    /**
+     * Extends the definition
+     *
+     * @param string   $name
+     * @param callable $callable
+     *
+     * @return void
+     * @throws Invalid
+     * @throws NotFound
+     */
     public function extend(string $name, callable $callable): void
     {
         $name = $this->resolveAlias($name);
@@ -110,6 +164,15 @@ class Container implements Collection
         $this->services[$name]->addExtender($callable);
     }
 
+    /**
+     * Resolve and return an element registerd in the container
+     *
+     * @param string $name
+     *
+     * @return mixed
+     * @throws Invalid
+     * @throws NotFound
+     */
     public function get(string $name): mixed
     {
         $name = $this->resolveAlias($name);
@@ -125,11 +188,25 @@ class Container implements Collection
         return $this->resolve($name, true);
     }
 
+    /**
+     * Return an alias
+     *
+     * @param string $name
+     *
+     * @return string
+     */
     public function getAlias(string $name): string
     {
         return $this->aliases[$name] ?? '';
     }
 
+    /**
+     * Return services by tag
+     *
+     * @param string $tag
+     *
+     * @return list<mixed>
+     */
     public function getByTag(string $tag): array
     {
         $names  = $this->tags[$tag] ?? [];
@@ -142,6 +219,14 @@ class Container implements Collection
         return $result;
     }
 
+    /**
+     * Return the service definition
+     *
+     * @param string $name
+     *
+     * @return ServiceDefinition
+     * @throws NotFound
+     */
     public function getDefinition(string $name): ServiceDefinition
     {
         if (!array_key_exists($name, $this->services)) {
@@ -151,6 +236,14 @@ class Container implements Collection
         return $this->services[$name];
     }
 
+    /**
+     * Return a stored instance
+     *
+     * @param string $name
+     *
+     * @return object
+     * @throws NotFound
+     */
     public function getInstance(string $name): object
     {
         if (!array_key_exists($name, $this->instances)) {
@@ -160,6 +253,14 @@ class Container implements Collection
         return $this->instances[$name];
     }
 
+    /**
+     * Return a parameter
+     *
+     * @param string $name
+     *
+     * @return mixed
+     * @throws NotFound
+     */
     public function getParameter(string $name): mixed
     {
         if (!array_key_exists($name, $this->parameters)) {
@@ -169,11 +270,25 @@ class Container implements Collection
         return $this->resolveParameter($name);
     }
 
+    /**
+     * Return the resolver
+     *
+     * @return Resolver
+     */
     public function getResolver(): Resolver
     {
         return $this->resolver;
     }
 
+    /**
+     * Resolve an return a service
+     *
+     * @param string $serviceName
+     *
+     * @return object
+     * @throws Invalid
+     * @throws NotFound
+     */
     public function getService(string $serviceName): object
     {
         $result = $this->get($serviceName);
@@ -185,6 +300,14 @@ class Container implements Collection
         return $result;
     }
 
+    /**
+     * Does the container have a particular service
+     *
+     * @param string $name
+     *
+     * @return bool
+     * @throws Invalid
+     */
     public function has(string $name): bool
     {
         $name = $this->resolveAlias($name);
@@ -200,36 +323,86 @@ class Container implements Collection
         return $this->autowire && $this->resolver->isResolvableClass($name);
     }
 
+    /**
+     * Does the service have an alias
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
     public function hasAlias(string $name): bool
     {
         return array_key_exists($name, $this->aliases);
     }
 
+    /**
+     * Does the service have a definition
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
     public function hasDefinition(string $name): bool
     {
         return array_key_exists($name, $this->services);
     }
 
+    /**
+     * Does the service have an instance
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
     public function hasInstance(string $name): bool
     {
         return array_key_exists($name, $this->instances);
     }
 
+    /**
+     * Does the service have a parameter
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
     public function hasParameter(string $name): bool
     {
         return array_key_exists($name, $this->parameters);
     }
 
+    /**
+     * Does the container have a particular service
+     *
+     * @param string $serviceName
+     *
+     * @return bool
+     * @throws Invalid
+     */
     public function hasService(string $serviceName): bool
     {
         return $this->has($serviceName);
     }
 
+    /**
+     * Is AutoWiring enabled
+     *
+     * @return bool
+     */
     public function isAutowireEnabled(): bool
     {
         return $this->autowire;
     }
 
+    /**
+     * Resolve and return a new service
+     *
+     * @param string $name
+     *
+     * @return mixed
+     * @throws Invalid
+     * @throws NotFound
+     */
     public function new(string $name): mixed
     {
         $name = $this->resolveAlias($name);
@@ -237,12 +410,27 @@ class Container implements Collection
         return $this->resolve($name, false);
     }
 
+    /**
+     * Return a new service definition
+     *
+     * @param string $name
+     *
+     * @return ServiceDefinition
+     */
     public function newDefinition(string $name): ServiceDefinition
     {
         return new ServiceDefinition($name, 'string');
     }
 
-    public function registerTag(string $tag, string $serviceName): void
+    /**
+     * Register a tag with a service
+     *
+     * @param string $tag
+     * @param string $serviceName
+     *
+     * @return void
+     */
+    public function addTag(string $tag, string $serviceName): void
     {
         if (!array_key_exists($tag, $this->tags)) {
             $this->tags[$tag] = [];
@@ -253,6 +441,15 @@ class Container implements Collection
         }
     }
 
+    /**
+     * Set a service
+     *
+     * @param string $name
+     * @param mixed  $definition
+     *
+     * @return ServiceDefinition
+     * @throws Invalid
+     */
     public function set(string $name, mixed $definition): ServiceDefinition
     {
         $processor = $this->findProcessor($definition);
@@ -264,6 +461,16 @@ class Container implements Collection
         return $def;
     }
 
+    /**
+     * Set an alias
+     *
+     * @param string $name
+     * @param string $alias
+     *
+     * @return $this
+     * @throws Invalid
+     */
+
     public function setAlias(string $name, string $alias): static
     {
         $this->detectCircularAlias($alias, $name);
@@ -272,6 +479,13 @@ class Container implements Collection
         return $this;
     }
 
+    /**
+     * Set AutoWire
+     *
+     * @param bool $enabled
+     *
+     * @return $this
+     */
     public function setAutowire(bool $enabled): static
     {
         $this->autowire = $enabled;
@@ -279,6 +493,14 @@ class Container implements Collection
         return $this;
     }
 
+    /**
+     * Set a definition
+     *
+     * @param string            $name
+     * @param ServiceDefinition $definition
+     *
+     * @return $this
+     */
     public function setDefinition(string $name, ServiceDefinition $definition): static
     {
         $this->services[$name] = $definition;
@@ -286,6 +508,15 @@ class Container implements Collection
         return $this;
     }
 
+    /**
+     * Set an instance
+     *
+     * @param string $name
+     * @param object $instance
+     * @param string $lifetime
+     *
+     * @return $this
+     */
     public function setInstance(string $name, object $instance, string $lifetime): static
     {
         $this->instances[$name]         = $instance;
@@ -294,6 +525,14 @@ class Container implements Collection
         return $this;
     }
 
+    /**
+     * Set a parameter
+     *
+     * @param string $name
+     * @param mixed  $value
+     *
+     * @return $this
+     */
     public function setParameter(string $name, mixed $value): static
     {
         $this->parameters[$name] = $value;
@@ -301,21 +540,49 @@ class Container implements Collection
         return $this;
     }
 
+    /**
+     * Remove an alias
+     *
+     * @param string $name
+     *
+     * @return void
+     */
     public function unsetAlias(string $name): void
     {
         unset($this->aliases[$name]);
     }
 
+    /**
+     * Remove a definition
+     *
+     * @param string $name
+     *
+     * @return void
+     */
     public function unsetDefinition(string $name): void
     {
         unset($this->services[$name]);
     }
 
+    /**
+     * Remove an instance
+     *
+     * @param string $name
+     *
+     * @return void
+     */
     public function unsetInstance(string $name): void
     {
         unset($this->instances[$name], $this->instanceLifetimes[$name]);
     }
 
+    /**
+     * Remove instances based on lifetime
+     *
+     * @param string $lifetime
+     *
+     * @return void
+     */
     public function unsetInstances(string $lifetime): void
     {
         foreach ($this->instanceLifetimes as $name => $lt) {
@@ -325,11 +592,27 @@ class Container implements Collection
         }
     }
 
+    /**
+     * Remove a parameter
+     *
+     * @param string $name
+     *
+     * @return void
+     */
     public function unsetParameter(string $name): void
     {
         unset($this->parameters[$name]);
     }
 
+    /**
+     * Detect circular aliases
+     *
+     * @param string $alias
+     * @param string $target
+     *
+     * @return void
+     * @throws Invalid
+     */
     private function detectCircularAlias(string $alias, string $target): void
     {
         $current = $target;
@@ -353,6 +636,14 @@ class Container implements Collection
         }
     }
 
+    /**
+     * Locate a processor
+     *
+     * @param mixed $definition
+     *
+     * @return Processor
+     * @throws Invalid
+     */
     private function findProcessor(mixed $definition): Processor
     {
         foreach ($this->processors as $processor) {
@@ -364,6 +655,17 @@ class Container implements Collection
         throw Invalid::noProcessorFound();
     }
 
+    /**
+     * Resolve the service
+     *
+     * @param string $name
+     * @param bool   $cache
+     *
+     * @return mixed
+     * @throws Invalid
+     * @throws NotFound
+     * @throws ReflectionException
+     */
     private function resolve(string $name, bool $cache): mixed
     {
         if (!array_key_exists($name, $this->services)) {
@@ -393,6 +695,14 @@ class Container implements Collection
         return $instance;
     }
 
+    /**
+     * Resolve an alias
+     *
+     * @param string $name
+     *
+     * @return string
+     * @throws Invalid
+     */
     private function resolveAlias(string $name): string
     {
         $seen    = [];
@@ -410,6 +720,13 @@ class Container implements Collection
         return $current;
     }
 
+    /**
+     * Resolve a paramater
+     *
+     * @param string $name
+     *
+     * @return mixed
+     */
     private function resolveParameter(string $name): mixed
     {
         $value = $this->parameters[$name];

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -47,6 +47,7 @@ use Phalcon\Container\Exception\NotFound;
 use Phalcon\Container\Resolver\Lazy\Lazy;
 use Phalcon\Container\Resolver\Resolver;
 use Phalcon\Container\Service\Collection;
+use Phalcon\Di\InjectionAwareInterface;
 
 use function array_key_exists;
 use function class_exists;
@@ -367,6 +368,10 @@ class Container implements Collection
         $definition->freeze($this);
 
         $instance = $definition->buildService($this);
+
+        if ($instance instanceof InjectionAwareInterface) {
+            $instance->setDI($this);
+        }
 
         $lifetime = $definition->getLifetime();
 

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -423,25 +423,6 @@ class Container implements Collection
     }
 
     /**
-     * Register a tag with a service
-     *
-     * @param string $tag
-     * @param string $serviceName
-     *
-     * @return void
-     */
-    public function addTag(string $tag, string $serviceName): void
-    {
-        if (!array_key_exists($tag, $this->tags)) {
-            $this->tags[$tag] = [];
-        }
-
-        if (!in_array($serviceName, $this->tags[$tag], true)) {
-            $this->tags[$tag][] = $serviceName;
-        }
-    }
-
-    /**
      * Set a service
      *
      * @param string $name
@@ -538,6 +519,25 @@ class Container implements Collection
         $this->parameters[$name] = $value;
 
         return $this;
+    }
+
+    /**
+     * Register a tag with a service
+     *
+     * @param string $tag
+     * @param string $serviceName
+     *
+     * @return void
+     */
+    public function setTag(string $tag, string $serviceName): void
+    {
+        if (!array_key_exists($tag, $this->tags)) {
+            $this->tags[$tag] = [];
+        }
+
+        if (!in_array($serviceName, $this->tags[$tag], true)) {
+            $this->tags[$tag][] = $serviceName;
+        }
     }
 
     /**

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -34,10 +34,8 @@ declare(strict_types=1);
 namespace Phalcon\Container;
 
 use Closure;
-use IocInterop\Interface\IocContainer;
 use Phalcon\Container\Definition\Processor\ClosureProcessor;
 use Phalcon\Container\Definition\Processor\ObjectProcessor;
-use Phalcon\Container\Definition\Processor\ParameterProcessor;
 use Phalcon\Container\Definition\Processor\Processor;
 use Phalcon\Container\Definition\Processor\StringProcessor;
 use Phalcon\Container\Definition\ServiceDefinition;
@@ -48,7 +46,6 @@ use Phalcon\Container\Resolver\Lazy\Lazy;
 use Phalcon\Container\Resolver\Resolver;
 use Phalcon\Container\Service\Collection;
 use Phalcon\Di\InjectionAwareInterface;
-
 use ReflectionException;
 
 use function array_key_exists;

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -264,31 +264,41 @@ class Container implements Collection
         return $def;
     }
 
-    public function setAlias(string $name, string $alias): void
+    public function setAlias(string $name, string $alias): static
     {
         $this->detectCircularAlias($alias, $name);
         $this->aliases[$alias] = $name;
+
+        return $this;
     }
 
-    public function setAutowire(bool $enabled): void
+    public function setAutowire(bool $enabled): static
     {
         $this->autowire = $enabled;
+
+        return $this;
     }
 
-    public function setDefinition(string $name, ServiceDefinition $definition): void
+    public function setDefinition(string $name, ServiceDefinition $definition): static
     {
         $this->services[$name] = $definition;
+
+        return $this;
     }
 
-    public function setInstance(string $name, object $instance, string $lifetime): void
+    public function setInstance(string $name, object $instance, string $lifetime): static
     {
         $this->instances[$name]         = $instance;
         $this->instanceLifetimes[$name] = $lifetime;
+
+        return $this;
     }
 
-    public function setParameter(string $name, mixed $value): void
+    public function setParameter(string $name, mixed $value): static
     {
         $this->parameters[$name] = $value;
+
+        return $this;
     }
 
     public function unsetAlias(string $name): void

--- a/src/Container/ContainerFactory.php
+++ b/src/Container/ContainerFactory.php
@@ -38,14 +38,29 @@ use Phalcon\Container\Service\Provider;
 
 class ContainerFactory implements IocContainerFactory
 {
+    /**
+     * @var array<array-key, Provider>
+     */
     protected array $providers = [];
 
+    /**
+     * Adds a provider
+     *
+     * @param Provider $provider
+     *
+     * @return $this
+     */
     public function addProvider(Provider $provider): static
     {
         $this->providers[] = $provider;
         return $this;
     }
 
+    /**
+     * Returns a new container
+     *
+     * @return Container
+     */
     public function newContainer(): Container
     {
         $container = new Container();

--- a/src/Container/Definition/Processor/ClosureProcessor.php
+++ b/src/Container/Definition/Processor/ClosureProcessor.php
@@ -39,11 +39,27 @@ use Phalcon\Container\Definition\ServiceDefinition;
 
 class ClosureProcessor implements Processor
 {
+    /**
+     * Wheteher the definition is a Closure
+     *
+     * @param mixed $definition
+     *
+     * @return bool
+     */
     public function canProcess(mixed $definition): bool
     {
         return $definition instanceof Closure;
     }
 
+    /**
+     * Process the Closure
+     *
+     * @param string $name
+     * @param mixed  $definition
+     * @param object $container
+     *
+     * @return ServiceDefinition
+     */
     public function process(
         string $name,
         mixed $definition,

--- a/src/Container/Definition/Processor/ObjectProcessor.php
+++ b/src/Container/Definition/Processor/ObjectProcessor.php
@@ -41,11 +41,27 @@ use function is_object;
 
 class ObjectProcessor implements Processor
 {
+    /**
+     * Whether the definition is an Object (not Closure)
+     *
+     * @param mixed $definition
+     *
+     * @return bool
+     */
     public function canProcess(mixed $definition): bool
     {
         return is_object($definition) && !($definition instanceof Closure);
     }
 
+    /**
+     * Process the Object
+     *
+     * @param string $name
+     * @param mixed  $definition
+     * @param object $container
+     *
+     * @return ServiceDefinition
+     */
     public function process(
         string $name,
         mixed $definition,

--- a/src/Container/Definition/Processor/ParameterProcessor.php
+++ b/src/Container/Definition/Processor/ParameterProcessor.php
@@ -41,11 +41,27 @@ use function is_object;
 
 class ParameterProcessor implements Processor
 {
+    /**
+     * Whetehr the definition is a parameter
+     *
+     * @param mixed $definition
+     *
+     * @return bool
+     */
     public function canProcess(mixed $definition): bool
     {
         return true;
     }
 
+    /**
+     * Process the parameter
+     *
+     * @param string $name
+     * @param mixed  $definition
+     * @param object $container
+     *
+     * @return ServiceDefinition
+     */
     public function process(
         string $name,
         mixed $definition,

--- a/src/Container/Definition/Processor/Processor.php
+++ b/src/Container/Definition/Processor/Processor.php
@@ -37,8 +37,24 @@ use Phalcon\Container\Definition\ServiceDefinition;
 
 interface Processor
 {
+    /**
+     * Can this definition be processed?
+     *
+     * @param mixed $definition
+     *
+     * @return bool
+     */
     public function canProcess(mixed $definition): bool;
 
+    /**
+     * Process the definition
+     *
+     * @param string $name
+     * @param mixed  $definition
+     * @param object $container
+     *
+     * @return ServiceDefinition
+     */
     public function process(
         string $name,
         mixed $definition,

--- a/src/Container/Definition/Processor/StringProcessor.php
+++ b/src/Container/Definition/Processor/StringProcessor.php
@@ -41,11 +41,27 @@ use function is_string;
 
 class StringProcessor implements Processor
 {
+    /**
+     * Whether the definition is a class string
+     *
+     * @param mixed $definition
+     *
+     * @return bool
+     */
     public function canProcess(mixed $definition): bool
     {
         return is_string($definition) && class_exists($definition);
     }
 
+    /**
+     * Process the class string
+     *
+     * @param string $name
+     * @param mixed  $definition
+     * @param object $container
+     *
+     * @return ServiceDefinition
+     */
     public function process(
         string $name,
         mixed $definition,

--- a/src/Container/Definition/ServiceDefinition.php
+++ b/src/Container/Definition/ServiceDefinition.php
@@ -36,32 +36,52 @@ namespace Phalcon\Container\Definition;
 use Phalcon\Container\Exception\Invalid;
 use ReflectionClass;
 
+use ReflectionException;
+
 use function in_array;
 use function method_exists;
 
 class ServiceDefinition
 {
-    protected array $arguments       = [];
-    protected object|null $container    = null;
-    protected string|null $class     = null;
-    protected array $constructorArgs = [];
-    protected array $extenders       = [];
-    protected mixed $factory         = null;
-    protected bool $frozen           = false;
-    protected bool $isCacheable      = false;
-    protected string $lifetime       = ServiceLifetime::SCOPED;
-    protected mixed $raw             = null;
-    protected string $serviceName;
-    protected array $tags            = [];
-    protected string $type;
+    /**
+     * @var array<array-key, mixed>
+     */
+    protected array $arguments = [];
 
-    public function __construct(string $serviceName, string $type, mixed $raw = null)
-    {
-        $this->raw         = $raw;
-        $this->serviceName = $serviceName;
-        $this->type        = $type;
+    protected object|null $container = null;
+    protected string|null $class     = null;
+    /**
+     * @var array
+     */
+    protected array $constructorArgs = [];
+    /**
+     * @var array<array-key, callable>
+     */
+    protected array $extenders  = [];
+    protected mixed $factory    = null;
+    protected bool $frozen      = false;
+    protected bool $isCacheable = false;
+    protected string $lifetime  = ServiceLifetime::SCOPED;
+    /**
+     * @var array<array-key, string>
+     */
+    protected array $tags = [];
+
+    public function __construct(
+        protected string $serviceName,
+        protected string $type,
+        protected mixed $raw = null
+    ) {
     }
 
+    /**
+     * Adds an extender
+     *
+     * @param callable $extender
+     *
+     * @return $this
+     * @throws Invalid
+     */
     public function addExtender(callable $extender): static
     {
         $this->checkFrozen();
@@ -70,6 +90,14 @@ class ServiceDefinition
         return $this;
     }
 
+    /**
+     * Adds a tag
+     *
+     * @param string $tag
+     *
+     * @return $this
+     * @throws Invalid
+     */
     public function addTag(string $tag): static
     {
         $this->checkFrozen();
@@ -78,13 +106,24 @@ class ServiceDefinition
             $this->tags[] = $tag;
         }
 
-        if ($this->container !== null && method_exists($this->container, 'registerTag')) {
+        if (
+            $this->container !== null
+            && method_exists($this->container, 'registerTag')
+        ) {
             $this->container->registerTag($tag, $this->serviceName);
         }
 
         return $this;
     }
 
+    /**
+     * Builds a service and returns the instance back
+     *
+     * @param object $container
+     *
+     * @return object
+     * @throws ReflectionException
+     */
     public function buildService(object $container): object
     {
         if ($this->hasFactory()) {
@@ -103,6 +142,14 @@ class ServiceDefinition
         return $instance;
     }
 
+    /**
+     * Freezes the container
+     *
+     * @param object $container
+     *
+     * @return void
+     * @throws ReflectionException
+     */
     public function freeze(object $container): void
     {
         if ($this->frozen) {
@@ -133,11 +180,22 @@ class ServiceDefinition
         $this->frozen = true;
     }
 
+    /**
+     * Returns the arguments
+     *
+     * @return array
+     */
     public function getArguments(): array
     {
         return $this->arguments;
     }
 
+    /**
+     * Returns the class
+     *
+     * @return string
+     * @throws Invalid
+     */
     public function getClass(): string
     {
         if ($this->class === null) {
@@ -147,16 +205,32 @@ class ServiceDefinition
         return $this->class;
     }
 
+    /**
+     * Returns the constructor arguments
+     *
+     * @return array
+     */
     public function getConstructorArgs(): array
     {
         return $this->constructorArgs;
     }
 
+    /**
+     * Returns the extenders
+     *
+     * @return array<array-key, callable>
+     */
     public function getExtenders(): array
     {
         return $this->extenders;
     }
 
+    /**
+     * Returns the factory
+     *
+     * @return callable
+     * @throws Invalid
+     */
     public function getFactory(): callable
     {
         if ($this->factory === null) {
@@ -166,51 +240,105 @@ class ServiceDefinition
         return $this->factory;
     }
 
+    /**
+     * Returns the lifetime
+     *
+     * @return string
+     */
     public function getLifetime(): string
     {
         return $this->lifetime;
     }
 
+    /**
+     * Returns the name of the service
+     *
+     * @return string
+     */
     public function getServiceName(): string
     {
         return $this->serviceName;
     }
 
+    /**
+     * Returns the tags
+     *
+     * @return array<array-key, string>
+     */
     public function getTags(): array
     {
         return $this->tags;
     }
 
+    /**
+     * Returns the type
+     *
+     * @return string
+     */
     public function getType(): string
     {
         return $this->type;
     }
 
+    /**
+     * Does it have a class
+     *
+     * @return bool
+     */
     public function hasClass(): bool
     {
         return $this->class !== null;
     }
 
+    /**
+     * Do we have extenders
+     *
+     * @return bool
+     */
     public function hasExtenders(): bool
     {
         return !empty($this->extenders);
     }
 
+    /**
+     * Does it have a factory
+     *
+     * @return bool
+     */
     public function hasFactory(): bool
     {
         return $this->factory !== null;
     }
 
+    /**
+     * Is it cacheable
+     *
+     * @return bool
+     */
     public function isCacheable(): bool
     {
         return $this->isCacheable && $this->frozen;
     }
 
+    /**
+     * Is it frozen
+     *
+     * @return bool
+     */
     public function isFrozen(): bool
     {
         return $this->frozen;
     }
 
+    /**
+     * Set an argument
+     *
+     * @param int|string $param
+     * @param mixed      $value
+     *
+     * @return $this
+     * @throws Invalid
+     */
     public function setArgument(int|string $param, mixed $value): static
     {
         $this->checkFrozen();
@@ -219,6 +347,13 @@ class ServiceDefinition
         return $this;
     }
 
+    /**
+     * Set the container
+     *
+     * @param object $container
+     *
+     * @return $this
+     */
     public function setContainer(object $container): static
     {
         $this->container = $container;
@@ -226,6 +361,14 @@ class ServiceDefinition
         return $this;
     }
 
+    /**
+     * Set a class
+     *
+     * @param string $class
+     *
+     * @return $this
+     * @throws Invalid
+     */
     public function setClass(string $class): static
     {
         $this->checkFrozen();
@@ -234,14 +377,37 @@ class ServiceDefinition
         return $this;
     }
 
+    /**
+     * Set extenders
+     *
+     * @param array<array-key, callable> $extenders
+     *
+     * @return $this
+     * @throws Invalid
+     */
     public function setExtenders(array $extenders): static
     {
         $this->checkFrozen();
+
+        foreach ($extenders as $key => $extender) {
+            if (!is_callable($extender)) {
+                throw Invalid::invalidExtender($this->serviceName, $key);
+            }
+        }
+
         $this->extenders = $extenders;
 
         return $this;
     }
 
+    /**
+     * Set a factory
+     *
+     * @param callable $factory
+     *
+     * @return $this
+     * @throws Invalid
+     */
     public function setFactory(callable $factory): static
     {
         $this->checkFrozen();
@@ -250,6 +416,13 @@ class ServiceDefinition
         return $this;
     }
 
+    /**
+     * Set cachable
+     * @param bool $isCacheable
+     *
+     * @return $this
+     * @throws Invalid
+     */
     public function setIsCacheable(bool $isCacheable): static
     {
         $this->checkFrozen();
@@ -258,6 +431,14 @@ class ServiceDefinition
         return $this;
     }
 
+    /**
+     * Set lifetime
+     *
+     * @param string $lifetime
+     *
+     * @return $this
+     * @throws Invalid
+     */
     public function setLifetime(string $lifetime): static
     {
         $this->checkFrozen();
@@ -266,6 +447,12 @@ class ServiceDefinition
         return $this;
     }
 
+    /**
+     * Unset class
+     *
+     * @return $this
+     * @throws Invalid
+     */
     public function unsetClass(): static
     {
         $this->checkFrozen();
@@ -274,6 +461,12 @@ class ServiceDefinition
         return $this;
     }
 
+    /**
+     * Unset extenders
+     *
+     * @return $this
+     * @throws Invalid
+     */
     public function unsetExtenders(): static
     {
         $this->checkFrozen();
@@ -282,6 +475,12 @@ class ServiceDefinition
         return $this;
     }
 
+    /**
+     * Unset the factory
+     *
+     * @return $this
+     * @throws Invalid
+     */
     public function unsetFactory(): static
     {
         $this->checkFrozen();
@@ -290,6 +489,12 @@ class ServiceDefinition
         return $this;
     }
 
+    /**
+     * Check if frozen
+     *
+     * @return void
+     * @throws Invalid
+     */
     protected function checkFrozen(): void
     {
         if ($this->frozen) {
@@ -297,6 +502,14 @@ class ServiceDefinition
         }
     }
 
+    /**
+     * Resolve arguments
+     *
+     * @param object $container
+     * @param array  $args
+     *
+     * @return array
+     */
     private function resolveArgs(object $container, array $args): array
     {
         $resolved = [];

--- a/src/Container/Definition/ServiceDefinition.php
+++ b/src/Container/Definition/ServiceDefinition.php
@@ -364,15 +364,15 @@ class ServiceDefinition
     /**
      * Set a class
      *
-     * @param string $class
+     * @param string $className
      *
      * @return $this
      * @throws Invalid
      */
-    public function setClass(string $class): static
+    public function setClass(string $className): static
     {
         $this->checkFrozen();
-        $this->class = $class;
+        $this->class = $className;
 
         return $this;
     }

--- a/src/Container/Definition/ServiceDefinition.php
+++ b/src/Container/Definition/ServiceDefinition.php
@@ -108,9 +108,9 @@ class ServiceDefinition
 
         if (
             $this->container !== null
-            && method_exists($this->container, 'addTag')
+            && method_exists($this->container, 'setTag')
         ) {
-            $this->container->addTag($tag, $this->serviceName);
+            $this->container->setTag($tag, $this->serviceName);
         }
 
         return $this;

--- a/src/Container/Definition/ServiceDefinition.php
+++ b/src/Container/Definition/ServiceDefinition.php
@@ -35,7 +35,6 @@ namespace Phalcon\Container\Definition;
 
 use Phalcon\Container\Exception\Invalid;
 use ReflectionClass;
-
 use ReflectionException;
 
 use function in_array;

--- a/src/Container/Definition/ServiceDefinition.php
+++ b/src/Container/Definition/ServiceDefinition.php
@@ -108,9 +108,9 @@ class ServiceDefinition
 
         if (
             $this->container !== null
-            && method_exists($this->container, 'registerTag')
+            && method_exists($this->container, 'addTag')
         ) {
-            $this->container->registerTag($tag, $this->serviceName);
+            $this->container->addTag($tag, $this->serviceName);
         }
 
         return $this;

--- a/src/Container/Exception/Invalid.php
+++ b/src/Container/Exception/Invalid.php
@@ -37,11 +37,26 @@ use Exception;
 
 class Invalid extends Exception implements ContainerThrowable
 {
+    /**
+     * Cannot extend a resolved service
+     *
+     * @param string $name
+     *
+     * @return static
+     */
     public static function cannotExtendResolved(string $name): static
     {
         return new static("Cannot extend already-resolved service '{$name}'");
     }
 
+    /**
+     * Cannot resolve a parameter
+     *
+     * @param string $param
+     * @param string $class
+     *
+     * @return static
+     */
     public static function cannotResolveParameter(string $param, string $class): static
     {
         return new static(
@@ -49,31 +64,86 @@ class Invalid extends Exception implements ContainerThrowable
         );
     }
 
+    /**
+     * Circular Alias found
+     *
+     * @param string $name
+     *
+     * @return static
+     */
     public static function circularAlias(string $name): static
     {
         return new static("Circular alias detected: '{$name}'");
     }
 
+    /**
+     * Definition is frozen
+     *
+     * @param string $name
+     *
+     * @return static
+     */
     public static function frozenDefinition(string $name): static
     {
         return new static("Cannot modify frozen definition '{$name}'");
     }
 
+    /**
+     * Invalid extender (not callable)
+     *
+     * @param string     $service
+     * @param int|string $key
+     *
+     * @return static
+     */
+    public static function invalidExtender(string $service, int|string $key): static
+    {
+        return new static(
+            "Extender at key '{$key}' for service '{$service}' is not callable"
+        );
+    }
+
+    /**
+     * No set for service
+     *
+     * @param string $name
+     *
+     * @return static
+     */
     public static function noClassSet(string $name): static
     {
         return new static("No class set for service '{$name}'");
     }
 
+    /**
+     * No factory for service
+     *
+     * @param string $name
+     *
+     * @return static
+     */
     public static function noFactorySet(string $name): static
     {
         return new static("No factory set for service '{$name}'");
     }
 
+    /**
+     * No processor found
+     *
+     * @return static
+     */
     public static function noProcessorFound(): static
     {
         return new static('No processor found for the given definition');
     }
 
+    /**
+     * Service not registered
+     *
+     * @param string $name
+     *
+     * @return static
+     */
     public static function serviceNotFound(string $name): static
     {
         return new static("Service '{$name}' not registered");

--- a/src/Container/Exception/Invalid.php
+++ b/src/Container/Exception/Invalid.php
@@ -46,7 +46,7 @@ class Invalid extends Exception implements ContainerThrowable
      */
     public static function cannotExtendResolved(string $name): static
     {
-        return new static("Cannot extend already-resolved service '{$name}'");
+        return new self("Cannot extend already-resolved service '{$name}'");
     }
 
     /**
@@ -59,7 +59,7 @@ class Invalid extends Exception implements ContainerThrowable
      */
     public static function cannotResolveParameter(string $param, string $className): static
     {
-        return new static(
+        return new self(
             "Cannot resolve parameter '\${$param}' for '{$className}'"
         );
     }
@@ -73,7 +73,7 @@ class Invalid extends Exception implements ContainerThrowable
      */
     public static function circularAlias(string $name): static
     {
-        return new static("Circular alias detected: '{$name}'");
+        return new self("Circular alias detected: '{$name}'");
     }
 
     /**
@@ -85,7 +85,7 @@ class Invalid extends Exception implements ContainerThrowable
      */
     public static function frozenDefinition(string $name): static
     {
-        return new static("Cannot modify frozen definition '{$name}'");
+        return new self("Cannot modify frozen definition '{$name}'");
     }
 
     /**
@@ -98,7 +98,7 @@ class Invalid extends Exception implements ContainerThrowable
      */
     public static function invalidExtender(string $service, int|string $key): static
     {
-        return new static(
+        return new self(
             "Extender at key '{$key}' for service '{$service}' is not callable"
         );
     }
@@ -112,7 +112,7 @@ class Invalid extends Exception implements ContainerThrowable
      */
     public static function noClassSet(string $name): static
     {
-        return new static("No class set for service '{$name}'");
+        return new self("No class set for service '{$name}'");
     }
 
     /**
@@ -124,7 +124,7 @@ class Invalid extends Exception implements ContainerThrowable
      */
     public static function noFactorySet(string $name): static
     {
-        return new static("No factory set for service '{$name}'");
+        return new self("No factory set for service '{$name}'");
     }
 
     /**
@@ -134,7 +134,7 @@ class Invalid extends Exception implements ContainerThrowable
      */
     public static function noProcessorFound(): static
     {
-        return new static('No processor found for the given definition');
+        return new self('No processor found for the given definition');
     }
 
     /**
@@ -146,6 +146,6 @@ class Invalid extends Exception implements ContainerThrowable
      */
     public static function serviceNotFound(string $name): static
     {
-        return new static("Service '{$name}' not registered");
+        return new self("Service '{$name}' not registered");
     }
 }

--- a/src/Container/Exception/Invalid.php
+++ b/src/Container/Exception/Invalid.php
@@ -53,14 +53,14 @@ class Invalid extends Exception implements ContainerThrowable
      * Cannot resolve a parameter
      *
      * @param string $param
-     * @param string $class
+     * @param string $className
      *
      * @return static
      */
-    public static function cannotResolveParameter(string $param, string $class): static
+    public static function cannotResolveParameter(string $param, string $className): static
     {
         return new static(
-            "Cannot resolve parameter '\${$param}' for '{$class}'"
+            "Cannot resolve parameter '\${$param}' for '{$className}'"
         );
     }
 

--- a/src/Container/Exception/NotFound.php
+++ b/src/Container/Exception/NotFound.php
@@ -33,25 +33,25 @@ declare(strict_types=1);
 
 namespace Phalcon\Container\Exception;
 
-class NotFound extends Invalid
+final class NotFound extends Invalid
 {
     public static function envNotDefined(string $varname): static
     {
-        return new static("Environment variable '{$varname}' is not defined");
+        return new self("Environment variable '{$varname}' is not defined");
     }
 
     public static function instanceNotFound(string $name): static
     {
-        return new static("Instance '{$name}' not found");
+        return new self("Instance '{$name}' not found");
     }
 
     public static function parameterNotFound(string $name): static
     {
-        return new static("Parameter '{$name}' not found");
+        return new self("Parameter '{$name}' not found");
     }
 
     public static function serviceNotFound(string $name): static
     {
-        return new static("Service '{$name}' not found");
+        return new self("Service '{$name}' not found");
     }
 }

--- a/src/Container/Provider/Cli.php
+++ b/src/Container/Provider/Cli.php
@@ -35,6 +35,7 @@ namespace Phalcon\Container\Provider;
 
 use Phalcon\Annotations\Adapter\Memory as AnnotationsMemory;
 use Phalcon\Annotations\Annotations;
+use Phalcon\Container\Exception\Invalid;
 use Phalcon\Container\Resolver\Lazy\LazyFactory;
 use Phalcon\Container\Service\Collection;
 use Phalcon\Container\Service\Provider;
@@ -63,6 +64,14 @@ use Phalcon\Support\Settings;
 
 class Cli implements Provider
 {
+    /**
+     * Provider for commonly used CLI applications
+     *
+     * @param Collection $services
+     *
+     * @return void
+     * @throws Invalid
+     */
     public function provide(Collection $services): void
     {
         // --- Interface bindings (bind + alias) ---

--- a/src/Container/Provider/Web.php
+++ b/src/Container/Provider/Web.php
@@ -36,6 +36,7 @@ namespace Phalcon\Container\Provider;
 use Phalcon\Annotations\Adapter\Memory as AnnotationsMemory;
 use Phalcon\Annotations\Annotations;
 use Phalcon\Assets\Manager as AssetsManager;
+use Phalcon\Container\Exception\Invalid;
 use Phalcon\Container\Resolver\Lazy\LazyFactory;
 use Phalcon\Container\Service\Collection;
 use Phalcon\Container\Service\Provider;
@@ -77,6 +78,14 @@ use Phalcon\Support\Settings;
 
 class Web implements Provider
 {
+    /**
+     * Provider for commonly used Web applications
+     *
+     * @param Collection $services
+     *
+     * @return void
+     * @throws Invalid
+     */
     public function provide(Collection $services): void
     {
         // --- Interface bindings (bind + alias) ---

--- a/src/Container/Resolver/Lazy/ArrayValues.php
+++ b/src/Container/Resolver/Lazy/ArrayValues.php
@@ -40,6 +40,9 @@ use IteratorAggregate;
 
 class ArrayValues extends Lazy implements ArrayAccess, Countable, IteratorAggregate
 {
+    /**
+     * @param array<array-key, mixed> $values
+     */
     public function __construct(
         protected array $values = []
     ) {
@@ -90,6 +93,13 @@ class ArrayValues extends Lazy implements ArrayAccess, Countable, IteratorAggreg
         unset($this->values[$offset]);
     }
 
+    /**
+     * Resolve to an array, where each element has itself been lazy-resolved.
+     *
+     * @param object $container
+     *
+     * @return array<array-key, mixed>
+     */
     public function resolve(object $container): array
     {
         return $this->resolveValues($container, $this->values);
@@ -108,6 +118,12 @@ class ArrayValues extends Lazy implements ArrayAccess, Countable, IteratorAggreg
         return $value;
     }
 
+    /**
+     * @param object                  $container
+     * @param array<array-key, mixed> $values
+     *
+     * @return array
+     */
     protected function resolveValues(object $container, array $values): array
     {
         $return = [];

--- a/src/Container/Resolver/Lazy/Call.php
+++ b/src/Container/Resolver/Lazy/Call.php
@@ -40,6 +40,13 @@ class Call extends Lazy
     ) {
     }
 
+    /**
+     * Resolve the callable
+     *
+     * @param object $container
+     *
+     * @return mixed
+     */
     public function resolve(object $container): mixed
     {
         return ($this->callable)($container);

--- a/src/Container/Resolver/Lazy/CallableGet.php
+++ b/src/Container/Resolver/Lazy/CallableGet.php
@@ -40,10 +40,18 @@ class CallableGet extends Lazy
     ) {
     }
 
+    /**
+     * Resolve to a closure on a get()
+     *
+     * @param object $container
+     *
+     * @return mixed
+     */
     public function resolve(object $container): mixed
     {
         return function () use ($container) {
             $id = $this->resolveArgument($container, $this->id);
+
             return $container->get($id);
         };
     }

--- a/src/Container/Resolver/Lazy/CallableNew.php
+++ b/src/Container/Resolver/Lazy/CallableNew.php
@@ -40,10 +40,18 @@ class CallableNew extends Lazy
     ) {
     }
 
+    /**
+     * Resolve to a closure on a new()
+     *
+     * @param object $container
+     *
+     * @return mixed
+     */
     public function resolve(object $container): mixed
     {
         return function () use ($container) {
             $id = $this->resolveArgument($container, $this->id);
+
             return $container->new($id);
         };
     }

--- a/src/Container/Resolver/Lazy/CsEnv.php
+++ b/src/Container/Resolver/Lazy/CsEnv.php
@@ -33,8 +33,18 @@ declare(strict_types=1);
 
 namespace Phalcon\Container\Resolver\Lazy;
 
+use Phalcon\Container\Exception\NotFound;
+
 class CsEnv extends Env
 {
+    /**
+     * Resolve the getEnv() from keys as a comma separated list
+     *
+     * @param object $container
+     *
+     * @return array
+     * @throws NotFound
+     */
     public function resolve(object $container): array
     {
         $values = str_getcsv($this->getEnv(), ',', '"', '\\');

--- a/src/Container/Resolver/Lazy/Env.php
+++ b/src/Container/Resolver/Lazy/Env.php
@@ -43,6 +43,14 @@ class Env extends Lazy
     ) {
     }
 
+    /**
+     * Resolve an environment variable
+     *
+     * @param object $container
+     *
+     * @return mixed
+     * @throws NotFound
+     */
     public function resolve(object $container): mixed
     {
         $value = $this->getEnv();

--- a/src/Container/Resolver/Lazy/FunctionCall.php
+++ b/src/Container/Resolver/Lazy/FunctionCall.php
@@ -35,12 +35,23 @@ namespace Phalcon\Container\Resolver\Lazy;
 
 class FunctionCall extends Lazy
 {
+    /**
+     * @param string                  $function
+     * @param array<array-key, mixed> $arguments
+     */
     public function __construct(
         protected string $function,
         protected array $arguments
     ) {
     }
 
+    /**
+     * Resolve a function
+     *
+     * @param object $container
+     *
+     * @return mixed
+     */
     public function resolve(object $container): mixed
     {
         $arguments = $this->resolveArguments($container, $this->arguments);

--- a/src/Container/Resolver/Lazy/Get.php
+++ b/src/Container/Resolver/Lazy/Get.php
@@ -40,9 +40,17 @@ class Get extends Lazy
     ) {
     }
 
+    /**
+     * Resolve a shared instance
+     *
+     * @param object $container
+     *
+     * @return mixed
+     */
     public function resolve(object $container): mixed
     {
         $id = $this->resolveArgument($container, $this->id);
+
         return $container->get($id);
     }
 }

--- a/src/Container/Resolver/Lazy/GetCall.php
+++ b/src/Container/Resolver/Lazy/GetCall.php
@@ -35,6 +35,11 @@ namespace Phalcon\Container\Resolver\Lazy;
 
 class GetCall extends Lazy
 {
+    /**
+     * @param string|Lazy             $id
+     * @param string                  $method
+     * @param array<array-key, mixed> $arguments
+     */
     public function __construct(
         protected string|Lazy $id,
         protected string $method,
@@ -42,6 +47,13 @@ class GetCall extends Lazy
     ) {
     }
 
+    /**
+     * Resolve a shared instance method call
+     *
+     * @param object $container
+     *
+     * @return mixed
+     */
     public function resolve(object $container): mixed
     {
         $id        = $this->resolveArgument($container, $this->id);

--- a/src/Container/Resolver/Lazy/Lazy.php
+++ b/src/Container/Resolver/Lazy/Lazy.php
@@ -53,6 +53,12 @@ abstract class Lazy implements Resolvable
         return $argument;
     }
 
+    /**
+     * @param object                  $container
+     * @param array<array-key, mixed> $arguments
+     *
+     * @return array<array-key, mixed>
+     */
     protected function resolveArguments(object $container, array $arguments): array
     {
         $resolved = [];

--- a/src/Container/Resolver/Lazy/LazyFactory.php
+++ b/src/Container/Resolver/Lazy/LazyFactory.php
@@ -90,8 +90,8 @@ class LazyFactory
         return new NewInstance($id);
     }
 
-    public static function staticCall(string $class, string $method, array $args): StaticCall
+    public static function staticCall(string $className, string $method, array $args): StaticCall
     {
-        return new StaticCall($class, $method, $args);
+        return new StaticCall($className, $method, $args);
     }
 }

--- a/src/Container/Resolver/Lazy/LazyFactory.php
+++ b/src/Container/Resolver/Lazy/LazyFactory.php
@@ -35,6 +35,11 @@ namespace Phalcon\Container\Resolver\Lazy;
 
 class LazyFactory
 {
+    /**
+     * @param array<array-key, mixed> $values
+     *
+     * @return ArrayValues
+     */
     public static function arrayValues(array $values): ArrayValues
     {
         return new ArrayValues($values);
@@ -65,6 +70,12 @@ class LazyFactory
         return new Env($name, $type);
     }
 
+    /**
+     * @param string                  $function
+     * @param array<array-key, mixed> $args
+     *
+     * @return FunctionCall
+     */
     public static function functionCall(string $function, array $args): FunctionCall
     {
         return new FunctionCall($function, $args);
@@ -75,11 +86,25 @@ class LazyFactory
         return new Get($id);
     }
 
+    /**
+     * @param string                  $id
+     * @param string                  $method
+     * @param array<array-key, mixed> $args
+     *
+     * @return GetCall
+     */
     public static function getCall(string $id, string $method, array $args): GetCall
     {
         return new GetCall($id, $method, $args);
     }
 
+    /**
+     * @param string                  $id
+     * @param string                  $method
+     * @param array<array-key, mixed> $args
+     *
+     * @return NewCall
+     */
     public static function newCall(string $id, string $method, array $args): NewCall
     {
         return new NewCall($id, $method, $args);
@@ -90,6 +115,13 @@ class LazyFactory
         return new NewInstance($id);
     }
 
+    /**
+     * @param string                  $className
+     * @param string                  $method
+     * @param array<array-key, mixed> $args
+     *
+     * @return StaticCall
+     */
     public static function staticCall(string $className, string $method, array $args): StaticCall
     {
         return new StaticCall($className, $method, $args);

--- a/src/Container/Resolver/Lazy/NewCall.php
+++ b/src/Container/Resolver/Lazy/NewCall.php
@@ -35,6 +35,11 @@ namespace Phalcon\Container\Resolver\Lazy;
 
 class NewCall extends Lazy
 {
+    /**
+     * @param string|Lazy             $id
+     * @param string                  $method
+     * @param array<array-key, mixed> $arguments
+     */
     public function __construct(
         protected string|Lazy $id,
         protected string $method,
@@ -42,6 +47,13 @@ class NewCall extends Lazy
     ) {
     }
 
+    /**
+     * Resolve a new instance method call
+     *
+     * @param object $container
+     *
+     * @return mixed
+     */
     public function resolve(object $container): mixed
     {
         $id        = $this->resolveArgument($container, $this->id);

--- a/src/Container/Resolver/Lazy/NewInstance.php
+++ b/src/Container/Resolver/Lazy/NewInstance.php
@@ -40,9 +40,17 @@ class NewInstance extends Lazy
     ) {
     }
 
+    /**
+     * Resolve a new instance
+     *
+     * @param object $container
+     *
+     * @return mixed
+     */
     public function resolve(object $container): mixed
     {
         $id = $this->resolveArgument($container, $this->id);
+
         return $container->new($id);
     }
 }

--- a/src/Container/Resolver/Lazy/StaticCall.php
+++ b/src/Container/Resolver/Lazy/StaticCall.php
@@ -36,7 +36,7 @@ namespace Phalcon\Container\Resolver\Lazy;
 class StaticCall extends Lazy
 {
     public function __construct(
-        protected string|Lazy $class,
+        protected string|Lazy $className,
         protected string $method,
         protected array $arguments
     ) {
@@ -44,9 +44,9 @@ class StaticCall extends Lazy
 
     public function resolve(object $container): mixed
     {
-        $class     = $this->resolveArgument($container, $this->class);
+        $className = $this->resolveArgument($container, $this->className);
         $arguments = $this->resolveArguments($container, $this->arguments);
 
-        return call_user_func_array([$class, $this->method], $arguments);
+        return call_user_func_array([$className, $this->method], $arguments);
     }
 }

--- a/src/Container/Resolver/Lazy/StaticCall.php
+++ b/src/Container/Resolver/Lazy/StaticCall.php
@@ -35,6 +35,11 @@ namespace Phalcon\Container\Resolver\Lazy;
 
 class StaticCall extends Lazy
 {
+    /**
+     * @param string|Lazy             $className
+     * @param string                  $method
+     * @param array<array-key, mixed> $arguments
+     */
     public function __construct(
         protected string|Lazy $className,
         protected string $method,
@@ -42,6 +47,13 @@ class StaticCall extends Lazy
     ) {
     }
 
+    /**
+     * Resolve a static method call
+     *
+     * @param object $container
+     *
+     * @return mixed
+     */
     public function resolve(object $container): mixed
     {
         $className = $this->resolveArgument($container, $this->className);

--- a/src/Container/Resolver/Resolver.php
+++ b/src/Container/Resolver/Resolver.php
@@ -51,13 +51,13 @@ use function method_exists;
 
 class Resolver implements ResolverService
 {
-    public function isResolvableClass(string $class): bool
+    public function isResolvableClass(string $className): bool
     {
-        if (!class_exists($class)) {
+        if (!class_exists($className)) {
             return false;
         }
 
-        return (new ReflectionClass($class))->isInstantiable();
+        return (new ReflectionClass($className))->isInstantiable();
     }
 
     public function resolveCall(
@@ -77,10 +77,10 @@ class Resolver implements ResolverService
 
     public function resolveClass(
         object $container,
-        string $class,
+        string $className,
         array $arguments
     ): object {
-        $reflection  = new ReflectionClass($class);
+        $reflection  = new ReflectionClass($className);
         $constructor = $reflection->getConstructor();
 
         if ($constructor === null) {

--- a/src/Container/Resolver/Resolver.php
+++ b/src/Container/Resolver/Resolver.php
@@ -38,6 +38,7 @@ use Phalcon\Container\Exception\Invalid;
 use Phalcon\Container\Resolver\Lazy\Lazy;
 use Phalcon\Container\Resolver\ResolverService;
 use ReflectionClass;
+use ReflectionException;
 use ReflectionFunction;
 use ReflectionMethod;
 use ReflectionNamedType;
@@ -51,6 +52,13 @@ use function method_exists;
 
 class Resolver implements ResolverService
 {
+    /**
+     * Is this a resolvable class?
+     *
+     * @param string $className
+     *
+     * @return bool
+     */
     public function isResolvableClass(string $className): bool
     {
         if (!class_exists($className)) {
@@ -60,6 +68,16 @@ class Resolver implements ResolverService
         return (new ReflectionClass($className))->isInstantiable();
     }
 
+    /**
+     * Resolve a call
+     *
+     * @param object   $container
+     * @param callable $callable
+     * @param array    $arguments
+     *
+     * @return mixed
+     * @throws ReflectionException
+     */
     public function resolveCall(
         object $container,
         callable $callable,
@@ -75,6 +93,16 @@ class Resolver implements ResolverService
         return call_user_func_array($callable, $resolved);
     }
 
+    /**
+     * Resolve a class
+     *
+     * @param object $container
+     * @param string $className
+     * @param array  $arguments
+     *
+     * @return object
+     * @throws ReflectionException
+     */
     public function resolveClass(
         object $container,
         string $className,
@@ -93,6 +121,16 @@ class Resolver implements ResolverService
         return $reflection->newInstanceArgs($resolved);
     }
 
+    /**
+     * Resolve a method
+     *
+     * @param object           $container
+     * @param ReflectionMethod $method
+     * @param object           $object
+     *
+     * @return void
+     * @throws ReflectionException
+     */
     public function resolveMethod(
         object $container,
         ReflectionMethod $method,
@@ -104,6 +142,16 @@ class Resolver implements ResolverService
         $method->invokeArgs($object, $resolved);
     }
 
+    /**
+     * Resolve parameters
+     *
+     * @param object              $container
+     * @param ReflectionParameter $parameter
+     *
+     * @return mixed
+     * @throws Invalid
+     * @throws ReflectionException
+     */
     public function resolveParameter(
         object $container,
         ReflectionParameter $parameter

--- a/src/Container/Resolver/ResolverService.php
+++ b/src/Container/Resolver/ResolverService.php
@@ -41,11 +41,11 @@ use ReflectionType;
 // Copied from resolver-interop/interface. Source: https://github.com/resolver-interop/interface
 interface ResolverService extends ReflectionParameterResolver
 {
-    public function isResolvableClass(string $class): bool;
+    public function isResolvableClass(string $className): bool;
 
     public function resolveCall(IocContainer $ioc, callable $callable, array $arguments): mixed;
 
-    public function resolveClass(IocContainer $ioc, string $class, array $arguments): object;
+    public function resolveClass(IocContainer $ioc, string $className, array $arguments): object;
 
     public function resolveMethod(IocContainer $ioc, ReflectionMethod $method, object $object): void;
 

--- a/src/Container/Service/Collection.php
+++ b/src/Container/Service/Collection.php
@@ -43,27 +43,27 @@ interface Collection extends IocContainer
     // From service-interop/ServiceCollection — alias management
     public function getAlias(string $name): string;
     public function hasAlias(string $name): bool;
-    public function setAlias(string $name, string $alias): void;
+    public function setAlias(string $name, string $alias): static;
     public function unsetAlias(string $name): void;
 
     // From service-interop/ServiceCollection — definition management
     public function getDefinition(string $name): ServiceDefinition;
     public function hasDefinition(string $name): bool;
     public function newDefinition(string $name): ServiceDefinition;
-    public function setDefinition(string $name, ServiceDefinition $definition): void;
+    public function setDefinition(string $name, ServiceDefinition $definition): static;
     public function unsetDefinition(string $name): void;
 
     // From service-interop/ServiceCollection — instance management
     public function getInstance(string $name): object;
     public function hasInstance(string $name): bool;
-    public function setInstance(string $name, object $instance, string $lifetime): void;
+    public function setInstance(string $name, object $instance, string $lifetime): static;
     public function unsetInstance(string $name): void;
     public function unsetInstances(string $lifetime): void;
 
     // Our additions — scalar parameters
     public function getParameter(string $name): mixed;
     public function hasParameter(string $name): bool;
-    public function setParameter(string $name, mixed $value): void;
+    public function setParameter(string $name, mixed $value): static;
     public function unsetParameter(string $name): void;
 
     // Our additions — Container-specific
@@ -78,5 +78,5 @@ interface Collection extends IocContainer
     public function isAutowireEnabled(): bool;
     public function new(string $name): mixed;
     public function set(string $name, mixed $definition): ServiceDefinition;
-    public function setAutowire(bool $enabled): void;
+    public function setAutowire(bool $enabled): static;
 }

--- a/src/Container/Service/Definition.php
+++ b/src/Container/Service/Definition.php
@@ -48,7 +48,7 @@ interface Definition
     public function hasClass(): bool;
     public function hasExtenders(): bool;
     public function hasFactory(): bool;
-    public function setClass(string $class): static;
+    public function setClass(string $className): static;
     public function setExtenders(array $extenders): static;
     public function setFactory(callable $factory): static;
     public function setLifetime(string $lifetime): static;

--- a/src/Container/Service/Definition.php
+++ b/src/Container/Service/Definition.php
@@ -49,6 +49,12 @@ interface Definition
     public function hasExtenders(): bool;
     public function hasFactory(): bool;
     public function setClass(string $className): static;
+
+    /**
+     * @param array<array-key, callable> $extenders
+     *
+     * @return $this
+     */
     public function setExtenders(array $extenders): static;
     public function setFactory(callable $factory): static;
     public function setLifetime(string $lifetime): static;

--- a/src/Dispatcher/AbstractDispatcher.php
+++ b/src/Dispatcher/AbstractDispatcher.php
@@ -17,6 +17,7 @@ use Exception as BaseException;
 use Phalcon\Cache\Adapter\AdapterInterface;
 use Phalcon\Cli\Dispatcher\Exception as CliDispatcherException;
 use Phalcon\Cli\TaskInterface;
+use Phalcon\Di\DiInterface;
 use Phalcon\Di\Injectable;
 use Phalcon\Dispatcher\Exception as DispatcherException;
 use Phalcon\Events\EventsAwareInterface;
@@ -352,7 +353,11 @@ abstract class AbstractDispatcher extends Injectable implements DispatcherInterf
                 break;
             }
 
-            $handler = $this->container->getShared($handlerClass);
+            if ($this->container instanceof DiInterface) {
+                $handler = $this->container->getShared($handlerClass);
+            } else {
+                $handler = $this->container->get($handlerClass);
+            }
 
             // Handlers must be only objects
             if (!is_object($handler)) {
@@ -948,7 +953,7 @@ abstract class AbstractDispatcher extends Injectable implements DispatcherInterf
         }
 
         /** @var FilterInterface $filter */
-        $filter = $this->container->getShared("filter");
+        $filter = $this->container->get("filter");
 
         return $filter->sanitize($paramValue, $filters);
     }

--- a/src/Dispatcher/AbstractDispatcher.php
+++ b/src/Dispatcher/AbstractDispatcher.php
@@ -953,7 +953,11 @@ abstract class AbstractDispatcher extends Injectable implements DispatcherInterf
         }
 
         /** @var FilterInterface $filter */
-        $filter = $this->container->get("filter");
+        if ($this->container instanceof DiInterface) {
+            $filter = $this->container->getShared("filter");
+        } else {
+            $filter = $this->container->get("filter");
+        }
 
         return $filter->sanitize($paramValue, $filters);
     }
@@ -1114,7 +1118,11 @@ abstract class AbstractDispatcher extends Injectable implements DispatcherInterf
         AdapterInterface | string | null $cache = null
     ): DispatcherInterface {
         if (is_string($cache)) {
-            $cache = $this->container->get($cache);
+            if ($this->container instanceof DiInterface) {
+                $cache = $this->container->getShared($cache);
+            } else {
+                $cache = $this->container->get($cache);
+            }
         }
 
         if ($cache instanceof AdapterInterface) {

--- a/src/Encryption/Security.php
+++ b/src/Encryption/Security.php
@@ -577,7 +577,7 @@ class Security implements InjectionAwareInterface
             null !== $this->container &&
             true === $this->container->has($name)
         ) {
-            $this->$property = $this->container->getShared($name);
+            $this->$property = $this->container->get($name);
         }
 
         return $this->$property;

--- a/src/Encryption/Security.php
+++ b/src/Encryption/Security.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Phalcon\Encryption;
 
 use Exception as BaseException;
+use Phalcon\Di\DiInterface;
 use Phalcon\Di\InjectionAwareInterface;
 use Phalcon\Di\Traits\InjectionAwareTrait;
 use Phalcon\Encryption\Security\Exception;
@@ -577,7 +578,11 @@ class Security implements InjectionAwareInterface
             null !== $this->container &&
             true === $this->container->has($name)
         ) {
-            $this->$property = $this->container->get($name);
+            if ($this->container instanceof DiInterface) {
+                $this->$property = $this->container->getShared($name);
+            } else {
+                $this->$property = $this->container->get($name);
+            }
         }
 
         return $this->$property;

--- a/src/Flash/AbstractFlash.php
+++ b/src/Flash/AbstractFlash.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Phalcon\Flash;
 
+use Phalcon\Di\DiInterface;
 use Phalcon\Di\InjectionAwareInterface;
 use Phalcon\Di\Traits\InjectionAwareTrait;
 use Phalcon\Flash\Traits\FlashGettersTrait;
@@ -106,7 +107,11 @@ abstract class AbstractFlash implements FlashInterface, InjectionAwareInterface
         }
 
         if (null === $this->escaperService) {
-            $this->escaperService = $this->container->get('escaper');
+            if ($this->container instanceof DiInterface) {
+                $this->escaperService = $this->container->getShared('escaper');
+            } else {
+                $this->escaperService = $this->container->get('escaper');
+            }
         }
 
 

--- a/src/Flash/AbstractFlash.php
+++ b/src/Flash/AbstractFlash.php
@@ -106,7 +106,7 @@ abstract class AbstractFlash implements FlashInterface, InjectionAwareInterface
         }
 
         if (null === $this->escaperService) {
-            $this->escaperService = $this->container->getShared('escaper');
+            $this->escaperService = $this->container->get('escaper');
         }
 
 

--- a/src/Flash/Session.php
+++ b/src/Flash/Session.php
@@ -78,7 +78,7 @@ class Session extends AbstractFlash
         }
 
         if (null === $this->sessionService) {
-            $this->sessionService = $this->container->getShared('session');
+            $this->sessionService = $this->container->get('session');
         }
 
 

--- a/src/Flash/Session.php
+++ b/src/Flash/Session.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Phalcon\Flash;
 
+use Phalcon\Di\DiInterface;
 use Phalcon\Session\ManagerInterface;
 
 /**
@@ -78,7 +79,11 @@ class Session extends AbstractFlash
         }
 
         if (null === $this->sessionService) {
-            $this->sessionService = $this->container->get('session');
+            if ($this->container instanceof DiInterface) {
+                $this->sessionService = $this->container->getShared('session');
+            } else {
+                $this->sessionService = $this->container->get('session');
+            }
         }
 
 

--- a/src/Forms/Element/AbstractElement.php
+++ b/src/Forms/Element/AbstractElement.php
@@ -591,7 +591,7 @@ abstract class AbstractElement implements ElementInterface
                 $container = Di::getDefault();
 
                 if (null !== $container && true === $container->has("tag")) {
-                    $tagFactory = $container->getShared("tag");
+                    $tagFactory = $container->get("tag");
                 }
             }
 

--- a/src/Forms/Element/AbstractElement.php
+++ b/src/Forms/Element/AbstractElement.php
@@ -15,6 +15,7 @@ namespace Phalcon\Forms\Element;
 
 use InvalidArgumentException;
 use Phalcon\Di\Di;
+use Phalcon\Di\DiInterface;
 use Phalcon\Filter\Validation\ValidatorInterface;
 use Phalcon\Forms\Exception;
 use Phalcon\Forms\Form;
@@ -591,7 +592,11 @@ abstract class AbstractElement implements ElementInterface
                 $container = Di::getDefault();
 
                 if (null !== $container && true === $container->has("tag")) {
-                    $tagFactory = $container->get("tag");
+                    if ($container instanceof DiInterface) {
+                        $tagFactory = $container->getShared("tag");
+                    } else {
+                        $tagFactory = $container->get("tag");
+                    }
                 }
             }
 

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -220,7 +220,7 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
             if (!empty($filters)) {
                 if (null === $filter) {
                     $container = $this->getDI();
-                    $filter    = $container->getShared("filter");
+                    $filter    = $container->get("filter");
                 }
 
                 /**

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -15,6 +15,7 @@ namespace Phalcon\Forms;
 
 use Countable;
 use Iterator;
+use Phalcon\Di\DiInterface;
 use Phalcon\Di\Injectable;
 use Phalcon\Filter\Validation;
 use Phalcon\Filter\Validation\Exception as ValidationException;
@@ -220,7 +221,11 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
             if (!empty($filters)) {
                 if (null === $filter) {
                     $container = $this->getDI();
-                    $filter    = $container->get("filter");
+                    if ($container instanceof DiInterface) {
+                        $filter = $container->getShared("filter");
+                    } else {
+                        $filter = $container->get("filter");
+                    }
                 }
 
                 /**

--- a/src/Http/Cookie.php
+++ b/src/Http/Cookie.php
@@ -107,7 +107,7 @@ class Cookie extends AbstractInjectionAware implements
             true === $this->container->has('session')
         ) {
             /** @var SessionManagerInterface $session */
-            $session = $this->container->getShared('session');
+            $session = $this->container->get('session');
 
             if (true === $session->exists()) {
                 $session->remove(self::COOKIE_PREFIX . $this->name);
@@ -234,7 +234,7 @@ class Cookie extends AbstractInjectionAware implements
                 }
 
                 /** @var CryptInterface $crypt */
-                $crypt = $this->container->getShared('crypt');
+                $crypt = $this->container->get('crypt');
 
                 if (!is_object($crypt)) {
                     throw new Exception(
@@ -277,7 +277,7 @@ class Cookie extends AbstractInjectionAware implements
                     }
 
                     /** @var FilterInterface $filter */
-                    $filter       = $this->container->getShared('filter');
+                    $filter       = $this->container->get('filter');
                     $this->filter = $filter;
                 }
 
@@ -320,7 +320,7 @@ class Cookie extends AbstractInjectionAware implements
                 true === $this->container->has('session')
             ) {
                 /** @var SessionManagerInterface $session */
-                $session = $this->container->getShared('session');
+                $session = $this->container->get('session');
 
                 if (true === $session->exists()) {
                     $definition = $session->get(
@@ -374,7 +374,7 @@ class Cookie extends AbstractInjectionAware implements
             true === $this->container->has('session')
         ) {
             /** @var SessionManagerInterface $session */
-            $session = $this->container->getShared('session');
+            $session = $this->container->get('session');
 
             if (true === $session->exists()) {
                 $session->set(self::COOKIE_PREFIX . $this->name, $definition);
@@ -391,7 +391,7 @@ class Cookie extends AbstractInjectionAware implements
             }
 
             /** @var CryptInterface $crypt */
-            $crypt = $this->container->getShared('crypt');
+            $crypt = $this->container->get('crypt');
 
             if (!is_object($crypt)) {
                 throw new Exception(

--- a/src/Http/Cookie.php
+++ b/src/Http/Cookie.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Phalcon\Http;
 
 use Phalcon\Di\AbstractInjectionAware;
+use Phalcon\Di\DiInterface;
 use Phalcon\Encryption\Crypt\CryptInterface;
 use Phalcon\Filter\FilterInterface;
 use Phalcon\Http\Cookie\CookieInterface;
@@ -107,7 +108,11 @@ class Cookie extends AbstractInjectionAware implements
             true === $this->container->has('session')
         ) {
             /** @var SessionManagerInterface $session */
-            $session = $this->container->get('session');
+            if ($this->container instanceof DiInterface) {
+                $session = $this->container->getShared('session');
+            } else {
+                $session = $this->container->get('session');
+            }
 
             if (true === $session->exists()) {
                 $session->remove(self::COOKIE_PREFIX . $this->name);
@@ -234,7 +239,11 @@ class Cookie extends AbstractInjectionAware implements
                 }
 
                 /** @var CryptInterface $crypt */
-                $crypt = $this->container->get('crypt');
+                if ($this->container instanceof DiInterface) {
+                    $crypt = $this->container->getShared('crypt');
+                } else {
+                    $crypt = $this->container->get('crypt');
+                }
 
                 if (!is_object($crypt)) {
                     throw new Exception(
@@ -277,7 +286,11 @@ class Cookie extends AbstractInjectionAware implements
                     }
 
                     /** @var FilterInterface $filter */
-                    $filter       = $this->container->get('filter');
+                    if ($this->container instanceof DiInterface) {
+                        $filter = $this->container->getShared('filter');
+                    } else {
+                        $filter = $this->container->get('filter');
+                    }
                     $this->filter = $filter;
                 }
 
@@ -320,7 +333,11 @@ class Cookie extends AbstractInjectionAware implements
                 true === $this->container->has('session')
             ) {
                 /** @var SessionManagerInterface $session */
-                $session = $this->container->get('session');
+                if ($this->container instanceof DiInterface) {
+                    $session = $this->container->getShared('session');
+                } else {
+                    $session = $this->container->get('session');
+                }
 
                 if (true === $session->exists()) {
                     $definition = $session->get(
@@ -374,7 +391,11 @@ class Cookie extends AbstractInjectionAware implements
             true === $this->container->has('session')
         ) {
             /** @var SessionManagerInterface $session */
-            $session = $this->container->get('session');
+            if ($this->container instanceof DiInterface) {
+                $session = $this->container->getShared('session');
+            } else {
+                $session = $this->container->get('session');
+            }
 
             if (true === $session->exists()) {
                 $session->set(self::COOKIE_PREFIX . $this->name, $definition);
@@ -391,7 +412,11 @@ class Cookie extends AbstractInjectionAware implements
             }
 
             /** @var CryptInterface $crypt */
-            $crypt = $this->container->get('crypt');
+            if ($this->container instanceof DiInterface) {
+                $crypt = $this->container->getShared('crypt');
+            } else {
+                $crypt = $this->container->get('crypt');
+            }
 
             if (!is_object($crypt)) {
                 throw new Exception(

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -1902,7 +1902,7 @@ class Request extends AbstractInjectionAware implements
             null !== $this->container &&
             null === $this->eventsManager
         ) {
-            $this->eventsManager = $this->container->getShared('eventsManager');
+            $this->eventsManager = $this->container->get('eventsManager');
         }
 
         if (null !== $this->eventsManager) {
@@ -2056,7 +2056,7 @@ class Request extends AbstractInjectionAware implements
                 );
             }
 
-            $this->filterService = $this->container->getShared("filter");
+            $this->filterService = $this->container->get("filter");
         }
 
         return $this->filterService;

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Phalcon\Http;
 
 use Phalcon\Di\AbstractInjectionAware;
+use Phalcon\Di\DiInterface;
 use Phalcon\Events\EventsAwareInterface;
 use Phalcon\Events\Exception as EventsException;
 use Phalcon\Events\Traits\EventsAwareTrait;
@@ -1902,7 +1903,11 @@ class Request extends AbstractInjectionAware implements
             null !== $this->container &&
             null === $this->eventsManager
         ) {
-            $this->eventsManager = $this->container->get('eventsManager');
+            if ($this->container instanceof DiInterface) {
+                $this->eventsManager = $this->container->getShared('eventsManager');
+            } else {
+                $this->eventsManager = $this->container->get('eventsManager');
+            }
         }
 
         if (null !== $this->eventsManager) {
@@ -2056,7 +2061,11 @@ class Request extends AbstractInjectionAware implements
                 );
             }
 
-            $this->filterService = $this->container->get("filter");
+            if ($this->container instanceof DiInterface) {
+                $this->filterService = $this->container->getShared("filter");
+            } else {
+                $this->filterService = $this->container->get("filter");
+            }
         }
 
         return $this->filterService;

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -16,6 +16,7 @@ namespace Phalcon\Http;
 use DateTime;
 use DateTimeZone;
 use InvalidArgumentException;
+use Phalcon\Container\Service\Collection;
 use Phalcon\Di\Di;
 use Phalcon\Di\DiInterface;
 use Phalcon\Di\Injectable;
@@ -153,10 +154,10 @@ class Response extends Injectable implements
     /**
      * Returns the internal dependency injector
      *
-     * @return DiInterface
+     * @return DiInterface|Collection
      * @throws Exception
      */
-    public function getDI(): DiInterface
+    public function getDI(): DiInterface | Collection
     {
         if (null === $this->container) {
             $container = Di::getDefault();
@@ -293,12 +294,12 @@ class Response extends Injectable implements
 
         if (empty($header)) {
             /** @var UrlInterface $url */
-            $url    = $container->getShared('url');
+            $url    = $container->get('url');
             $header = $url->get($location);
         }
 
         if (true === $container->has('view')) {
-            $view = $container->getShared('view');
+            $view = $container->get('view');
 
             if ($view instanceof ViewInterface) {
                 $view->disable();

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -294,12 +294,20 @@ class Response extends Injectable implements
 
         if (empty($header)) {
             /** @var UrlInterface $url */
-            $url    = $container->get('url');
+            if ($container instanceof DiInterface) {
+                $url = $container->getShared('url');
+            } else {
+                $url = $container->get('url');
+            }
             $header = $url->get($location);
         }
 
         if (true === $container->has('view')) {
-            $view = $container->get('view');
+            if ($container instanceof DiInterface) {
+                $view = $container->getShared('view');
+            } else {
+                $view = $container->get('view');
+            }
 
             if ($view instanceof ViewInterface) {
                 $view->disable();

--- a/src/Http/Response/Cookies.php
+++ b/src/Http/Response/Cookies.php
@@ -326,7 +326,7 @@ class Cookies extends AbstractInjectionAware implements CookiesInterface
             }
 
             /** @var ResponseInterface $response */
-            $response = $this->container->getShared('response');
+            $response = $this->container->get('response');
 
             /**
              * Pass the cookies bag to the response so it can send the headers

--- a/src/Http/Response/Cookies.php
+++ b/src/Http/Response/Cookies.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Phalcon\Http\Response;
 
 use Phalcon\Di\AbstractInjectionAware;
+use Phalcon\Di\DiInterface;
 use Phalcon\Http\Cookie;
 use Phalcon\Http\Cookie\CookieInterface;
 use Phalcon\Http\Cookie\Exception;
@@ -326,7 +327,11 @@ class Cookies extends AbstractInjectionAware implements CookiesInterface
             }
 
             /** @var ResponseInterface $response */
-            $response = $this->container->get('response');
+            if ($this->container instanceof DiInterface) {
+                $response = $this->container->getShared('response');
+            } else {
+                $response = $this->container->get('response');
+            }
 
             /**
              * Pass the cookies bag to the response so it can send the headers

--- a/src/Mvc/Application.php
+++ b/src/Mvc/Application.php
@@ -16,6 +16,7 @@ namespace Phalcon\Mvc;
 use Closure;
 use Phalcon\Application\AbstractApplication;
 use Phalcon\Application\Exception as ApplicationException;
+use Phalcon\Di\DiInterface;
 use Phalcon\Events\Exception as EventsException;
 use Phalcon\Http\ResponseInterface;
 use Phalcon\Mvc\Application\Exception;
@@ -112,7 +113,11 @@ class Application extends AbstractApplication
             return false;
         }
 
-        $router = $this->container->get("router");
+        if ($this->container instanceof DiInterface) {
+            $router = $this->container->getShared("router");
+        } else {
+            $router = $this->container->get("router");
+        }
 
         /**
          * Handle the URI pattern (if any)
@@ -145,7 +150,11 @@ class Application extends AbstractApplication
                  * If the returned value is a string return it as body
                  */
                 if (is_string($possibleResponse)) {
-                    $response = $this->container->get("response");
+                    if ($this->container instanceof DiInterface) {
+                        $response = $this->container->getShared("response");
+                    } else {
+                        $response = $this->container->get("response");
+                    }
 
                     $response->setContent($possibleResponse);
 
@@ -257,14 +266,22 @@ class Application extends AbstractApplication
          */
         $view = null;
         if (true === $this->implicitView) {
-            $view = $this->container->get("view");
+            if ($this->container instanceof DiInterface) {
+                $view = $this->container->getShared("view");
+            } else {
+                $view = $this->container->get("view");
+            }
         }
 
         /**
          * We get the parameters from the router and assign them to the dispatcher
          * Assign the values passed from the router
          */
-        $dispatcher = $this->container->get("dispatcher");
+        if ($this->container instanceof DiInterface) {
+            $dispatcher = $this->container->getShared("dispatcher");
+        } else {
+            $dispatcher = $this->container->get("dispatcher");
+        }
 
         $dispatcher->setModuleName($router->getModuleName());
         $dispatcher->setNamespaceName($router->getNamespaceName());
@@ -300,13 +317,21 @@ class Application extends AbstractApplication
          * Returning false from an action cancels the view
          */
         if (false === $possibleResponse) {
-            $response = $this->container->get("response");
+            if ($this->container instanceof DiInterface) {
+                $response = $this->container->getShared("response");
+            } else {
+                $response = $this->container->get("response");
+            }
         } else {
             /**
              * Returning a string makes use it as the body of the response
              */
             if (is_string($possibleResponse)) {
-                $response = $this->container->get("response");
+                if ($this->container instanceof DiInterface) {
+                    $response = $this->container->getShared("response");
+                } else {
+                    $response = $this->container->get("response");
+                }
 
                 $response->setContent($possibleResponse);
             } else {
@@ -364,7 +389,11 @@ class Application extends AbstractApplication
                      */
                     $response = $possibleResponse;
                 } else {
-                    $response = $this->container->get("response");
+                    if ($this->container instanceof DiInterface) {
+                        $response = $this->container->getShared("response");
+                    } else {
+                        $response = $this->container->get("response");
+                    }
 
                     if (true === $this->implicitView) {
                         /**

--- a/src/Mvc/Application.php
+++ b/src/Mvc/Application.php
@@ -112,7 +112,7 @@ class Application extends AbstractApplication
             return false;
         }
 
-        $router = $this->container->getShared("router");
+        $router = $this->container->get("router");
 
         /**
          * Handle the URI pattern (if any)
@@ -145,7 +145,7 @@ class Application extends AbstractApplication
                  * If the returned value is a string return it as body
                  */
                 if (is_string($possibleResponse)) {
-                    $response = $this->container->getShared("response");
+                    $response = $this->container->get("response");
 
                     $response->setContent($possibleResponse);
 
@@ -257,14 +257,14 @@ class Application extends AbstractApplication
          */
         $view = null;
         if (true === $this->implicitView) {
-            $view = $this->container->getShared("view");
+            $view = $this->container->get("view");
         }
 
         /**
          * We get the parameters from the router and assign them to the dispatcher
          * Assign the values passed from the router
          */
-        $dispatcher = $this->container->getShared("dispatcher");
+        $dispatcher = $this->container->get("dispatcher");
 
         $dispatcher->setModuleName($router->getModuleName());
         $dispatcher->setNamespaceName($router->getNamespaceName());
@@ -300,13 +300,13 @@ class Application extends AbstractApplication
          * Returning false from an action cancels the view
          */
         if (false === $possibleResponse) {
-            $response = $this->container->getShared("response");
+            $response = $this->container->get("response");
         } else {
             /**
              * Returning a string makes use it as the body of the response
              */
             if (is_string($possibleResponse)) {
-                $response = $this->container->getShared("response");
+                $response = $this->container->get("response");
 
                 $response->setContent($possibleResponse);
             } else {
@@ -364,7 +364,7 @@ class Application extends AbstractApplication
                      */
                     $response = $possibleResponse;
                 } else {
-                    $response = $this->container->getShared("response");
+                    $response = $this->container->get("response");
 
                     if (true === $this->implicitView) {
                         /**
@@ -415,7 +415,6 @@ class Application extends AbstractApplication
 
         return $this;
     }
-
 
     /**
      * Enables or disables sending headers by each request handling

--- a/src/Mvc/Dispatcher.php
+++ b/src/Mvc/Dispatcher.php
@@ -275,7 +275,7 @@ class Dispatcher extends BaseDispatcher implements DispatcherInterface
             Exception::EXCEPTION_NO_DI
         );
 
-        $response = $this->container->getShared("response");
+        $response = $this->container->get("response");
 
         /**
          * Dispatcher exceptions automatically sends a 404 status

--- a/src/Mvc/Dispatcher.php
+++ b/src/Mvc/Dispatcher.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Phalcon\Mvc;
 
 use Exception as BaseException;
+use Phalcon\Di\DiInterface;
 use Phalcon\Dispatcher\AbstractDispatcher as BaseDispatcher;
 use Phalcon\Dispatcher\Exception as DispatcherException;
 use Phalcon\Events\Exception as EventsException;
@@ -275,7 +276,11 @@ class Dispatcher extends BaseDispatcher implements DispatcherInterface
             Exception::EXCEPTION_NO_DI
         );
 
-        $response = $this->container->get("response");
+        if ($this->container instanceof DiInterface) {
+            $response = $this->container->getShared("response");
+        } else {
+            $response = $this->container->get("response");
+        }
 
         /**
          * Dispatcher exceptions automatically sends a 404 status

--- a/src/Mvc/Micro.php
+++ b/src/Mvc/Micro.php
@@ -16,6 +16,7 @@ namespace Phalcon\Mvc;
 use ArrayAccess;
 use Closure;
 use Phalcon\Cache\Adapter\AdapterInterface;
+use Phalcon\Container\Service\Collection;
 use Phalcon\Di\DiInterface;
 use Phalcon\Di\FactoryDefault;
 use Phalcon\Di\Injectable;
@@ -126,8 +127,10 @@ class Micro extends Injectable implements ArrayAccess, EventsAwareInterface
 
     /**
      * Phalcon\Mvc\Micro constructor
+     *
+     * @param DiInterface|Collection|null $container
      */
-    public function __construct(DiInterface | null $container = null)
+    public function __construct(DiInterface | Collection | null $container = null)
     {
         if (null !== $container) {
             $this->setDi($container);
@@ -330,7 +333,7 @@ class Micro extends Injectable implements ArrayAccess, EventsAwareInterface
     {
         $this->checkDiContainer();
 
-        return $this->container->getShared($serviceName);
+        return $this->container->get($serviceName);
     }
 
     /**
@@ -366,7 +369,7 @@ class Micro extends Injectable implements ArrayAccess, EventsAwareInterface
              * Handling routing information
              */
             /** @var Router $router */
-            $router = $this->container->getShared("router");
+            $router = $this->container->get("router");
 
             /**
              * Handle the URI as normal
@@ -697,7 +700,7 @@ class Micro extends Injectable implements ArrayAccess, EventsAwareInterface
              * body
              */
             if (is_string($returnedValue)) {
-                $response = $this->container->getShared("response");
+                $response = $this->container->get("response");
 
                 if (true !== $response->isSent()) {
                     $response->setContent($returnedValue);

--- a/src/Mvc/Micro.php
+++ b/src/Mvc/Micro.php
@@ -333,6 +333,10 @@ class Micro extends Injectable implements ArrayAccess, EventsAwareInterface
     {
         $this->checkDiContainer();
 
+        if ($this->container instanceof DiInterface) {
+            return $this->container->getShared($serviceName);
+        }
+
         return $this->container->get($serviceName);
     }
 
@@ -369,7 +373,11 @@ class Micro extends Injectable implements ArrayAccess, EventsAwareInterface
              * Handling routing information
              */
             /** @var Router $router */
-            $router = $this->container->get("router");
+            if ($this->container instanceof DiInterface) {
+                $router = $this->container->getShared("router");
+            } else {
+                $router = $this->container->get("router");
+            }
 
             /**
              * Handle the URI as normal
@@ -700,7 +708,11 @@ class Micro extends Injectable implements ArrayAccess, EventsAwareInterface
              * body
              */
             if (is_string($returnedValue)) {
-                $response = $this->container->get("response");
+                if ($this->container instanceof DiInterface) {
+                    $response = $this->container->getShared("response");
+                } else {
+                    $response = $this->container->get("response");
+                }
 
                 if (true !== $response->isSent()) {
                     $response->setContent($returnedValue);

--- a/src/Mvc/Model.php
+++ b/src/Mvc/Model.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Phalcon\Mvc;
 
 use JsonSerializable;
+use Phalcon\Container\Service\Collection as ServiceCollection;
 use Phalcon\Db\Adapter\AdapterInterface;
 use Phalcon\Db\Column;
 use Phalcon\Db\Enum;
@@ -197,15 +198,15 @@ abstract class Model extends AbstractInjectionAware implements
     /**
      * Phalcon\Mvc\Model constructor
      *
-     * @param array|null            $data
-     * @param DiInterface|null      $container
-     * @param ManagerInterface|null $modelsManager
+     * @param array|null                     $data
+     * @param DiInterface|ServiceCollection|null $container
+     * @param ManagerInterface|null          $modelsManager
      *
      * @throws Exception
      */
     final public function __construct(
         array | null $data = null,
-        DiInterface | null $container = null,
+        DiInterface | ServiceCollection | null $container = null,
         ManagerInterface | null $modelsManager = null
     ) {
         /**
@@ -2835,11 +2836,11 @@ abstract class Model extends AbstractInjectionAware implements
     /**
      * Create a criteria for a specific model
      *
-     * @param DiInterface|null $container
+     * @param DiInterface|ServiceCollection|null $container
      *
      * @return CriteriaInterface
      */
-    public static function query(DiInterface | null $container = null): CriteriaInterface
+    public static function query(DiInterface | ServiceCollection | null $container = null): CriteriaInterface
     {
         /**
          * Use the global dependency injector if there is no one defined
@@ -2855,10 +2856,11 @@ abstract class Model extends AbstractInjectionAware implements
             $criteria = $container->get(
                 "Phalcon\\Mvc\\Model\\Criteria"
             );
+        } elseif (null !== $container) {
+            $criteria = new Criteria();
+            $criteria->setDI($container);
         } else {
             $criteria = new Criteria();
-
-            $criteria->setDI($container);
         }
 
         $criteria->setModelName(get_called_class());

--- a/src/Mvc/Model/Criteria.php
+++ b/src/Mvc/Model/Criteria.php
@@ -276,7 +276,11 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
             $this->setDI($container);
         }
 
-        $manager = $container->get("modelsManager");
+        if ($container instanceof DiInterface) {
+            $manager = $container->getShared("modelsManager");
+        } else {
+            $manager = $container->get("modelsManager");
+        }
 
         /**
          * Builds a query with the passed parameters
@@ -353,7 +357,11 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
         $bind       = [];
 
         if (count($data)) {
-            $metaData  = $container->get("modelsMetadata");
+            if ($container instanceof DiInterface) {
+                $metaData = $container->getShared("modelsMetadata");
+            } else {
+                $metaData = $container->get("modelsMetadata");
+            }
             $model     = new $modelName(null, $container);
             $dataTypes = $metaData->getDataTypes($model);
             $columnMap = $metaData->getReverseColumnMap($model);

--- a/src/Mvc/Model/Criteria.php
+++ b/src/Mvc/Model/Criteria.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Phalcon\Mvc\Model;
 
+use Phalcon\Container\Service\Collection;
 use Phalcon\Db\Column;
 use Phalcon\Di\Di;
 use Phalcon\Di\DiInterface;
@@ -275,7 +276,7 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
             $this->setDI($container);
         }
 
-        $manager = $container->getShared("modelsManager");
+        $manager = $container->get("modelsManager");
 
         /**
          * Builds a query with the passed parameters
@@ -335,15 +336,15 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
     /**
      * Builds a Phalcon\Mvc\Model\Criteria based on an input array like $_POST
      *
-     * @param DiInterface $container
-     * @param string      $modelName
-     * @param array       $data
-     * @param string      $operator
+     * @param DiInterface|Collection $container
+     * @param string                 $modelName
+     * @param array                  $data
+     * @param string                 $operator
      *
      * @return CriteriaInterface
      */
     public static function fromInput(
-        DiInterface $container,
+        DiInterface | Collection $container,
         string $modelName,
         array $data,
         string $operator = "AND"
@@ -352,7 +353,7 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
         $bind       = [];
 
         if (count($data)) {
-            $metaData  = $container->getShared("modelsMetadata");
+            $metaData  = $container->get("modelsMetadata");
             $model     = new $modelName(null, $container);
             $dataTypes = $metaData->getDataTypes($model);
             $columnMap = $metaData->getReverseColumnMap($model);
@@ -433,9 +434,9 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
     /**
      * Returns the DependencyInjector container
      *
-     * @return DiInterface
+     * @return DiInterface|Collection
      */
-    public function getDI(): DiInterface
+    public function getDI(): DiInterface | Collection
     {
         return $this->params["di"];
     }

--- a/src/Mvc/Model/Manager.php
+++ b/src/Mvc/Model/Manager.php
@@ -2119,7 +2119,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
         /**
          * Request the connection service from the DI
          */
-        $connection = $this->container->getShared($service);
+        $connection = $this->container->get($service);
 
         if (!is_object($connection)) {
             throw new Exception("Invalid injected connection service");

--- a/src/Mvc/Model/Manager.php
+++ b/src/Mvc/Model/Manager.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Phalcon\Mvc\Model;
 
 use Phalcon\Db\Adapter\AdapterInterface;
+use Phalcon\Di\DiInterface;
 use Phalcon\Di\InjectionAwareInterface;
 use Phalcon\Di\Traits\InjectionAwareTrait;
 use Phalcon\Events\EventsAwareInterface;
@@ -2119,7 +2120,11 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
         /**
          * Request the connection service from the DI
          */
-        $connection = $this->container->get($service);
+        if ($this->container instanceof DiInterface) {
+            $connection = $this->container->getShared($service);
+        } else {
+            $connection = $this->container->get($service);
+        }
 
         if (!is_object($connection)) {
             throw new Exception("Invalid injected connection service");

--- a/src/Mvc/Model/MetaData.php
+++ b/src/Mvc/Model/MetaData.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Phalcon\Mvc\Model;
 
 use Phalcon\Cache\Adapter\AdapterInterface as CacheAdapterInterface;
+use Phalcon\Container\Service\Collection;
 use Phalcon\Di\DiInterface;
 use Phalcon\Di\Injectable;
 use Phalcon\Mvc\Model\MetaData\Strategy\Introspection;
@@ -255,10 +256,10 @@ abstract class MetaData extends Injectable implements MetaDataInterface
     /**
      * Returns the DependencyInjector container
      *
-     * @return DiInterface
+     * @return DiInterface|Collection
      * @throws Exception
      */
-    public function getDI(): DiInterface
+    public function getDI(): DiInterface | Collection
     {
         $this->checkContainer(
             Exception::class,

--- a/src/Mvc/Model/MetaData/Strategy/Annotations.php
+++ b/src/Mvc/Model/MetaData/Strategy/Annotations.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Phalcon\Mvc\Model\MetaData\Strategy;
 
 use Phalcon\Annotations\Parser\Collection;
+use Phalcon\Container\Service\Collection as ServiceCollection;
 use Phalcon\Db\Column;
 use Phalcon\Di\DiInterface;
 use Phalcon\Mvc\Model\Exception;
@@ -23,14 +24,14 @@ use Phalcon\Mvc\ModelInterface;
 class Annotations implements StrategyInterface
 {
     /**
-     * @param ModelInterface $model
-     * @param DiInterface    $container
+     * @param ModelInterface                  $model
+     * @param DiInterface|ServiceCollection   $container
      *
      * @return array
      * @throws \Phalcon\Annotations\Parser\Exception
      * @throws Exception
      */
-    public function getColumnMaps(ModelInterface $model, DiInterface $container): array
+    public function getColumnMaps(ModelInterface $model, DiInterface | ServiceCollection $container): array
     {
         $propertiesAnnotations = $this->getProperties($model, $container);
 
@@ -78,14 +79,14 @@ class Annotations implements StrategyInterface
     }
 
     /**
-     * @param ModelInterface $model
-     * @param DiInterface    $container
+     * @param ModelInterface                  $model
+     * @param DiInterface|ServiceCollection   $container
      *
      * @return array
      * @throws \Phalcon\Annotations\Parser\Exception
      * @throws Exception
      */
-    public function getMetaData(ModelInterface $model, DiInterface $container): array
+    public function getMetaData(ModelInterface $model, DiInterface | ServiceCollection $container): array
     {
         $propertiesAnnotations = $this->getProperties($model, $container);
 
@@ -272,13 +273,13 @@ class Annotations implements StrategyInterface
     }
 
     /**
-     * @param ModelInterface $model
-     * @param DiInterface    $container
+     * @param ModelInterface                  $model
+     * @param DiInterface|ServiceCollection   $container
      *
      * @return Collection[]
      * @throws Exception
      */
-    private function getProperties(ModelInterface $model, DiInterface $container): array
+    private function getProperties(ModelInterface $model, DiInterface | ServiceCollection $container): array
     {
         if (false === is_object($container)) {
             throw new Exception("The dependency injector is invalid in MetaData Strategy Annotations");

--- a/src/Mvc/Model/MetaData/Strategy/Introspection.php
+++ b/src/Mvc/Model/MetaData/Strategy/Introspection.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Phalcon\Mvc\Model\MetaData\Strategy;
 
+use Phalcon\Container\Service\Collection;
 use Phalcon\Di\DiInterface;
 use Phalcon\Mvc\Model\Exception;
 use Phalcon\Mvc\Model\MetaData;
@@ -28,7 +29,7 @@ class Introspection implements StrategyInterface
     /**
      * Read the model's column map, this can't be inferred
      */
-    final public function getColumnMaps(ModelInterface $model, DiInterface $container): array
+    final public function getColumnMaps(ModelInterface $model, DiInterface | Collection $container): array
     {
         $orderedColumnMap  = null;
         $reversedColumnMap = null;
@@ -60,7 +61,7 @@ class Introspection implements StrategyInterface
     /**
      * The meta-data is obtained by reading the column descriptions from the database information schema
      */
-    final public function getMetaData(ModelInterface $model, DiInterface $container): array
+    final public function getMetaData(ModelInterface $model, DiInterface | Collection $container): array
     {
         $schema = $model->getSchema();
         $table  = $model->getSource();

--- a/src/Mvc/Model/MetaData/Strategy/StrategyInterface.php
+++ b/src/Mvc/Model/MetaData/Strategy/StrategyInterface.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Phalcon\Mvc\Model\MetaData\Strategy;
 
+use Phalcon\Container\Service\Collection;
 use Phalcon\Di\DiInterface;
 use Phalcon\Mvc\ModelInterface;
 
@@ -21,8 +22,8 @@ interface StrategyInterface
     /**
      * Read the model's column map, this can't be inferred
      *
-     * @param ModelInterface $model
-     * @param DiInterface    $container
+     * @param ModelInterface      $model
+     * @param DiInterface|Collection $container
      *
      * @return array
      * @todo Not implemented
@@ -30,20 +31,20 @@ interface StrategyInterface
      */
     public function getColumnMaps(
         ModelInterface $model,
-        DiInterface $container
+        DiInterface | Collection $container
     ): array;
 
     /**
      * The meta-data is obtained by reading the column descriptions from the
      * database information schema
      *
-     * @param ModelInterface $model
-     * @param DiInterface    $container
+     * @param ModelInterface         $model
+     * @param DiInterface|Collection $container
      *
      * @return array
      */
     public function getMetaData(
         ModelInterface $model,
-        DiInterface $container
+        DiInterface | Collection $container
     ): array;
 }

--- a/src/Mvc/Model/Query.php
+++ b/src/Mvc/Model/Query.php
@@ -311,7 +311,11 @@ class Query implements QueryInterface, InjectionAwareInterface
             $cacheService = $cacheOptions["service"] ?? "modelsCache";
 
             /** @var CacheInterface $cache */
-            $cache = $this->container->get($cacheService);
+            if ($this->container instanceof DiInterface) {
+                $cache = $this->container->getShared($cacheService);
+            } else {
+                $cache = $this->container->get($cacheService);
+            }
 
             if (!$cache instanceof CacheInterface) {
                 throw new Exception(
@@ -704,13 +708,21 @@ class Query implements QueryInterface, InjectionAwareInterface
      */
     public function setDI(object $container): void
     {
-        $manager = $container->get("modelsManager");
+        if ($container instanceof DiInterface) {
+            $manager = $container->getShared("modelsManager");
+        } else {
+            $manager = $container->get("modelsManager");
+        }
 
         if (!is_object($manager)) {
             throw new Exception("Injected service 'modelsManager' is invalid");
         }
 
-        $metaData = $container->get("modelsMetadata");
+        if ($container instanceof DiInterface) {
+            $metaData = $container->getShared("modelsMetadata");
+        } else {
+            $metaData = $container->get("modelsMetadata");
+        }
 
         if (!is_object($metaData)) {
             throw new Exception("Injected service 'modelsMetaData' is invalid");

--- a/src/Mvc/Model/Query.php
+++ b/src/Mvc/Model/Query.php
@@ -19,6 +19,7 @@ use Phalcon\Db\Adapter\AdapterInterface;
 use Phalcon\Db\Column;
 use Phalcon\Db\RawValue;
 use Phalcon\Db\ResultInterface;
+use Phalcon\Container\Service\Collection;
 use Phalcon\Di\DiInterface;
 use Phalcon\Di\InjectionAwareInterface;
 use Phalcon\Di\Traits\InjectionAwareTrait;
@@ -226,15 +227,15 @@ class Query implements QueryInterface, InjectionAwareInterface
     /**
      * Phalcon\Mvc\Model\Query constructor
      *
-     * @param string|null      $phql
-     * @param DiInterface|null $container
-     * @param array            $options
+     * @param string|null                  $phql
+     * @param DiInterface|Collection|null  $container
+     * @param array                        $options
      *
      * @throws Exception
      */
     public function __construct(
         protected string | null $phql = null,
-        DiInterface | null $container = null,
+        DiInterface | Collection | null $container = null,
         array $options = []
     ) {
         if (null !== $container) {
@@ -310,7 +311,7 @@ class Query implements QueryInterface, InjectionAwareInterface
             $cacheService = $cacheOptions["service"] ?? "modelsCache";
 
             /** @var CacheInterface $cache */
-            $cache = $this->container->getShared($cacheService);
+            $cache = $this->container->get($cacheService);
 
             if (!$cache instanceof CacheInterface) {
                 throw new Exception(
@@ -703,13 +704,13 @@ class Query implements QueryInterface, InjectionAwareInterface
      */
     public function setDI(object $container): void
     {
-        $manager = $container->getShared("modelsManager");
+        $manager = $container->get("modelsManager");
 
         if (!is_object($manager)) {
             throw new Exception("Injected service 'modelsManager' is invalid");
         }
 
-        $metaData = $container->getShared("modelsMetadata");
+        $metaData = $container->get("modelsMetadata");
 
         if (!is_object($metaData)) {
             throw new Exception("Injected service 'modelsMetaData' is invalid");

--- a/src/Mvc/Model/Query/Builder.php
+++ b/src/Mvc/Model/Query/Builder.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Phalcon\Mvc\Model\Query;
 
+use Phalcon\Container\Service\Collection;
 use Phalcon\Db\Column;
 use Phalcon\Di\Di;
 use Phalcon\Di\DiInterface;
@@ -149,12 +150,12 @@ class Builder implements BuilderInterface, InjectionAwareInterface
     /**
      * Phalcon\Mvc\Model\Query\Builder constructor
      *
-     * @param array|string|null $params
-     * @param DiInterface|null  $container
+     * @param array|string|null            $params
+     * @param DiInterface|Collection|null  $container
      */
     public function __construct(
         array | string | null $params = null,
-        DiInterface | null $container = null
+        DiInterface | Collection | null $container = null
     ) {
         if (is_array($params)) {
             /**
@@ -653,9 +654,9 @@ class Builder implements BuilderInterface, InjectionAwareInterface
     /**
      * Returns the DependencyInjector container
      *
-     * @return DiInterface
+     * @return DiInterface|Collection
      */
-    public function getDI(): DiInterface
+    public function getDI(): DiInterface | Collection
     {
         return $this->container;
     }
@@ -804,7 +805,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
              * Get the models metadata service to obtain the column names,
              * column map and primary key
              */
-            $metaData      = $this->container->getShared("modelsMetadata");
+            $metaData      = $this->container->get("modelsMetadata");
             $modelInstance = new $model(null, $this->container);
             $noPrimary     = true;
             $primaryKeys   = $metaData->getPrimaryKeyAttributes($modelInstance);

--- a/src/Mvc/Model/Query/Builder.php
+++ b/src/Mvc/Model/Query/Builder.php
@@ -805,7 +805,11 @@ class Builder implements BuilderInterface, InjectionAwareInterface
              * Get the models metadata service to obtain the column names,
              * column map and primary key
              */
-            $metaData      = $this->container->get("modelsMetadata");
+            if ($this->container instanceof DiInterface) {
+                $metaData = $this->container->getShared("modelsMetadata");
+            } else {
+                $metaData = $this->container->get("modelsMetadata");
+            }
             $modelInstance = new $model(null, $this->container);
             $noPrimary     = true;
             $primaryKeys   = $metaData->getPrimaryKeyAttributes($modelInstance);

--- a/src/Mvc/Model/Resultset/Complex.php
+++ b/src/Mvc/Model/Resultset/Complex.php
@@ -15,6 +15,7 @@ namespace Phalcon\Mvc\Model\Resultset;
 
 use Phalcon\Db\ResultInterface;
 use Phalcon\Di\Di;
+use Phalcon\Di\DiInterface;
 use Phalcon\Mvc\Model;
 use Phalcon\Mvc\Model\Exception;
 use Phalcon\Mvc\Model\Resultset;
@@ -299,7 +300,11 @@ class Complex extends Resultset implements ResultsetInterface
         ];
 
         if ($container->has("serializer")) {
-            $serializer = $container->get("serializer");
+            if ($container instanceof DiInterface) {
+                $serializer = $container->getShared("serializer");
+            } else {
+                $serializer = $container->get("serializer");
+            }
             $serializer->setData($data);
 
             return $serializer->serialize();
@@ -354,7 +359,11 @@ class Complex extends Resultset implements ResultsetInterface
         }
 
         if ($container->has("serializer")) {
-            $serializer = $container->get("serializer");
+            if ($container instanceof DiInterface) {
+                $serializer = $container->getShared("serializer");
+            } else {
+                $serializer = $container->get("serializer");
+            }
 
             $serializer->unserialize($data);
             $resultset = $serializer->getData();

--- a/src/Mvc/Model/Resultset/Complex.php
+++ b/src/Mvc/Model/Resultset/Complex.php
@@ -299,7 +299,7 @@ class Complex extends Resultset implements ResultsetInterface
         ];
 
         if ($container->has("serializer")) {
-            $serializer = $container->getShared("serializer");
+            $serializer = $container->get("serializer");
             $serializer->setData($data);
 
             return $serializer->serialize();
@@ -354,7 +354,7 @@ class Complex extends Resultset implements ResultsetInterface
         }
 
         if ($container->has("serializer")) {
-            $serializer = $container->getShared("serializer");
+            $serializer = $container->get("serializer");
 
             $serializer->unserialize($data);
             $resultset = $serializer->getData();

--- a/src/Mvc/Model/Resultset/Simple.php
+++ b/src/Mvc/Model/Resultset/Simple.php
@@ -15,6 +15,7 @@ namespace Phalcon\Mvc\Model\Resultset;
 
 use Phalcon\Db\Enum;
 use Phalcon\Di\Di;
+use Phalcon\Di\DiInterface;
 use Phalcon\Mvc\Model;
 use Phalcon\Mvc\Model\Exception;
 use Phalcon\Mvc\Model\ResultInterface;
@@ -197,7 +198,11 @@ class Simple extends Resultset
         ];
 
         if ($container->has("serializer")) {
-            $serializer = $container->get("serializer");
+            if ($container instanceof DiInterface) {
+                $serializer = $container->getShared("serializer");
+            } else {
+                $serializer = $container->get("serializer");
+            }
             $serializer->setData($data);
 
             return $serializer->serialize();
@@ -305,7 +310,11 @@ class Simple extends Resultset
         }
 
         if ($container->has("serializer")) {
-            $serializer = $container->get("serializer");
+            if ($container instanceof DiInterface) {
+                $serializer = $container->getShared("serializer");
+            } else {
+                $serializer = $container->get("serializer");
+            }
 
             $serializer->unserialize($data);
             $resultset = $serializer->getData();

--- a/src/Mvc/Model/Resultset/Simple.php
+++ b/src/Mvc/Model/Resultset/Simple.php
@@ -197,7 +197,7 @@ class Simple extends Resultset
         ];
 
         if ($container->has("serializer")) {
-            $serializer = $container->getShared("serializer");
+            $serializer = $container->get("serializer");
             $serializer->setData($data);
 
             return $serializer->serialize();
@@ -305,7 +305,7 @@ class Simple extends Resultset
         }
 
         if ($container->has("serializer")) {
-            $serializer = $container->getShared("serializer");
+            $serializer = $container->get("serializer");
 
             $serializer->unserialize($data);
             $resultset = $serializer->getData();

--- a/src/Mvc/Model/Transaction.php
+++ b/src/Mvc/Model/Transaction.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Phalcon\Mvc\Model;
 
+use Phalcon\Container\Service\Collection;
 use Phalcon\Db\Adapter\AdapterInterface;
 use Phalcon\Di\DiInterface;
 use Phalcon\Mvc\Model\Transaction\Failed as TxFailed;
@@ -103,12 +104,12 @@ class Transaction implements TransactionInterface
     /**
      * Phalcon\Mvc\Model\Transaction constructor
      *
-     * @param DiInterface $container
-     * @param bool        $autoBegin
-     * @param string      $service
+     * @param DiInterface|Collection $container
+     * @param bool                   $autoBegin
+     * @param string                 $service
      */
     public function __construct(
-        DiInterface $container,
+        DiInterface | Collection $container,
         bool $autoBegin = false,
         string $service = "db"
     ) {

--- a/src/Mvc/Model/Transaction/Manager.php
+++ b/src/Mvc/Model/Transaction/Manager.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Phalcon\Mvc\Model\Transaction;
 
+use Phalcon\Container\Service\Collection;
 use Phalcon\Di\Di;
 use Phalcon\Di\DiInterface;
 use Phalcon\Di\InjectionAwareInterface;
@@ -179,9 +180,9 @@ class Manager implements ManagerInterface, InjectionAwareInterface
     /**
      * Returns the dependency injection container
      *
-     * @return DiInterface|null
+     * @return DiInterface|Collection|null
      */
-    public function getDI(): DiInterface | null
+    public function getDI(): DiInterface | Collection | null
     {
         return $this->container;
     }

--- a/src/Mvc/ModelInterface.php
+++ b/src/Mvc/ModelInterface.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Phalcon\Mvc;
 
+use Phalcon\Container\Service\Collection;
 use Phalcon\Db\Adapter\AdapterInterface;
 use Phalcon\Di\DiInterface;
 use Phalcon\Messages\MessageInterface;
@@ -293,12 +294,12 @@ interface ModelInterface
     /**
      * Create a criteria for a specific model
      *
-     * @param DiInterface|null $container
+     * @param DiInterface|Collection|null $container
      *
      * @return CriteriaInterface
      */
     public static function query(
-        DiInterface | null $container = null
+        DiInterface | Collection | null $container = null
     ): CriteriaInterface;
 
     /**

--- a/src/Mvc/ModuleDefinitionInterface.php
+++ b/src/Mvc/ModuleDefinitionInterface.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Phalcon\Mvc;
 
+use Phalcon\Container\Service\Collection;
 use Phalcon\Di\DiInterface;
 
 /**
@@ -23,18 +24,18 @@ interface ModuleDefinitionInterface
     /**
      * Registers an autoloader related to the module
      *
-     * @param DiInterface|null $container
+     * @param DiInterface|Collection|null $container
      *
      * @return void
      */
-    public function registerAutoloaders(DiInterface | null $container = null);
+    public function registerAutoloaders(DiInterface | Collection | null $container = null);
 
     /**
      * Registers services related to the module
      *
-     * @param DiInterface $container
+     * @param DiInterface|Collection $container
      *
      * @return void
      */
-    public function registerServices(DiInterface $container);
+    public function registerServices(DiInterface | Collection $container);
 }

--- a/src/Mvc/Router/Annotations.php
+++ b/src/Mvc/Router/Annotations.php
@@ -159,7 +159,7 @@ class Annotations extends Router
         }
 
         /** @var Memory $annotationsService */
-        $annotationsService = $this->container->getShared("annotations");
+        $annotationsService = $this->container->get("annotations");
 
         foreach ($this->handlers as $scope) {
             if (!is_array($scope)) {

--- a/src/Mvc/Router/Annotations.php
+++ b/src/Mvc/Router/Annotations.php
@@ -16,6 +16,7 @@ namespace Phalcon\Mvc\Router;
 use Phalcon\Annotations\Adapter\Memory;
 use Phalcon\Annotations\Parser\Annotation;
 use Phalcon\Annotations\Parser\Exception;
+use Phalcon\Di\DiInterface;
 use Phalcon\Events\Exception as EventsException;
 use Phalcon\Mvc\Router;
 use Phalcon\Traits\Helper\Str\UncamelizeTrait;
@@ -159,7 +160,11 @@ class Annotations extends Router
         }
 
         /** @var Memory $annotationsService */
-        $annotationsService = $this->container->get("annotations");
+        if ($this->container instanceof DiInterface) {
+            $annotationsService = $this->container->getShared("annotations");
+        } else {
+            $annotationsService = $this->container->get("annotations");
+        }
 
         foreach ($this->handlers as $scope) {
             if (!is_array($scope)) {

--- a/src/Mvc/Url.php
+++ b/src/Mvc/Url.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Phalcon\Mvc;
 
 use Phalcon\Di\AbstractInjectionAware;
+use Phalcon\Di\DiInterface;
 use Phalcon\Mvc\Url\Exception;
 use Phalcon\Mvc\Url\UrlInterface;
 
@@ -157,7 +158,11 @@ class Url extends AbstractInjectionAware implements UrlInterface
                     );
                 }
 
-                $this->router = $this->container->get("router");
+                if ($this->container instanceof DiInterface) {
+                    $this->router = $this->container->getShared("router");
+                } else {
+                    $this->router = $this->container->get("router");
+                }
             }
 
             /**

--- a/src/Mvc/Url.php
+++ b/src/Mvc/Url.php
@@ -157,7 +157,7 @@ class Url extends AbstractInjectionAware implements UrlInterface
                     );
                 }
 
-                $this->router = $this->container->getShared("router");
+                $this->router = $this->container->get("router");
             }
 
             /**

--- a/src/Mvc/View/Engine/AbstractEngine.php
+++ b/src/Mvc/View/Engine/AbstractEngine.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Phalcon\Mvc\View\Engine;
 
+use Phalcon\Container\Service\Collection;
 use Phalcon\Di\DiInterface;
 use Phalcon\Di\Injectable;
 use Phalcon\Events\EventsAwareInterface;
@@ -30,12 +31,12 @@ abstract class AbstractEngine extends Injectable implements EngineInterface, Eve
     /**
      * Phalcon\Mvc\View\Engine constructor
      *
-     * @param ViewBaseInterface $view
-     * @param DiInterface|null  $container
+     * @param ViewBaseInterface    $view
+     * @param DiInterface|Collection|null $container
      */
     public function __construct(
         protected ViewBaseInterface $view,
-        DiInterface | null $container = null
+        DiInterface | Collection | null $container = null
     ) {
         $this->container = $container;
     }

--- a/src/Mvc/View/Simple.php
+++ b/src/Mvc/View/Simple.php
@@ -537,7 +537,7 @@ class Simple extends Injectable implements ViewBaseInterface, EventsAwareInterfa
                         /**
                          * Engine can be a string representing a service in the DI
                          */
-                        $engineObject = $this->container->getShared(
+                        $engineObject = $this->container->get(
                             $engineService,
                             [
                                 $this,

--- a/src/Mvc/View/Simple.php
+++ b/src/Mvc/View/Simple.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Phalcon\Mvc\View;
 
 use Closure;
+use Phalcon\Di\DiInterface;
 use Phalcon\Di\Injectable;
 use Phalcon\Events\EventsAwareInterface;
 use Phalcon\Events\Exception as EventsException;
@@ -537,12 +538,21 @@ class Simple extends Injectable implements ViewBaseInterface, EventsAwareInterfa
                         /**
                          * Engine can be a string representing a service in the DI
                          */
-                        $engineObject = $this->container->get(
-                            $engineService,
-                            [
-                                $this,
-                            ]
-                        );
+                        if ($this->container instanceof DiInterface) {
+                            $engineObject = $this->container->getShared(
+                                $engineService,
+                                [
+                                    $this,
+                                ]
+                            );
+                        } else {
+                            $engineObject = $this->container->get(
+                                $engineService,
+                                [
+                                    $this,
+                                ]
+                            );
+                        }
                     } else {
                         throw new Exception(
                             "Invalid template engine registration for extension: "

--- a/src/Support/Debug/Dump.php
+++ b/src/Support/Debug/Dump.php
@@ -15,6 +15,7 @@ namespace Phalcon\Support\Debug;
 
 use InvalidArgumentException;
 use JsonException;
+use Phalcon\Container\Container;
 use Phalcon\Di\DiInterface;
 use Phalcon\Support\Helper\Json\Encode;
 use Phalcon\Traits\Helper\Str\InterpolateTrait;
@@ -364,8 +365,8 @@ class Dump
 
             $output .= " (\n";
 
-            if ($variable instanceof DiInterface) {
-                // Skip debugging di
+            if ($variable instanceof DiInterface || $variable instanceof Container) {
+                // Skip debugging di and container
                 $output .= str_repeat($space, $tab) . "[skipped]\n";
             } elseif (true !== $this->detailed || $variable instanceof stdClass) {
                 // Debug only public properties

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Phalcon;
 
+use Phalcon\Container\Service\Collection;
 use Phalcon\Di\Di;
 use Phalcon\Di\DiInterface;
 use Phalcon\Html\Escaper\EscaperInterface;
@@ -63,9 +64,9 @@ class Tag
     /**
      * DI Container
      *
-     * @var DiInterface|null
+     * @var DiInterface|Collection|null
      */
-    protected static DiInterface | null $container = null;
+    protected static DiInterface | Collection | null $container = null;
 
     /**
      * Pre-assigned values for components
@@ -352,9 +353,9 @@ class Tag
     /**
      * Internally gets the request dispatcher
      *
-     * @return DiInterface
+     * @return DiInterface|Collection
      */
-    public static function getDI(): DiInterface
+    public static function getDI(): DiInterface | Collection
     {
         if (null === self::$container) {
             self::$container = Di::getDefault();
@@ -440,7 +441,7 @@ class Tag
         if (null === self::$escaperService) {
             $container = self::getDI();
 
-            self::$escaperService = $container->getShared("escaper");
+            self::$escaperService = $container->get("escaper");
         }
 
         return self::$escaperService;
@@ -522,7 +523,7 @@ class Tag
         if (null === self::$urlService) {
             $container = self::getDI();
 
-            self::$urlService = $container->getShared("url");
+            self::$urlService = $container->get("url");
         }
 
         return self::$urlService;
@@ -1111,11 +1112,11 @@ class Tag
     /**
      * Sets the dependency injector container.
      *
-     * @param DiInterface $container
+     * @param DiInterface|Collection $container
      *
      * @return void
      */
-    public static function setDI(DiInterface $container): void
+    public static function setDI(DiInterface | Collection $container): void
     {
         self::$container = $container;
     }

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -441,7 +441,11 @@ class Tag
         if (null === self::$escaperService) {
             $container = self::getDI();
 
-            self::$escaperService = $container->get("escaper");
+            if ($container instanceof DiInterface) {
+                self::$escaperService = $container->getShared("escaper");
+            } else {
+                self::$escaperService = $container->get("escaper");
+            }
         }
 
         return self::$escaperService;
@@ -523,7 +527,11 @@ class Tag
         if (null === self::$urlService) {
             $container = self::getDI();
 
-            self::$urlService = $container->get("url");
+            if ($container instanceof DiInterface) {
+                self::$urlService = $container->getShared("url");
+            } else {
+                self::$urlService = $container->get("url");
+            }
         }
 
         return self::$urlService;

--- a/tests/support/Modules/Backend/Module.php
+++ b/tests/support/Modules/Backend/Module.php
@@ -2,8 +2,9 @@
 
 namespace Phalcon\Tests\Support\Modules\Backend;
 
-use Phalcon\Di\DiInterface;
 use Phalcon\Autoload\Loader;
+use Phalcon\Container\Service\Collection;
+use Phalcon\Di\DiInterface;
 use Phalcon\Mvc\ModuleDefinitionInterface;
 use Phalcon\Mvc\View;
 use function supportDir;
@@ -26,13 +27,13 @@ use function supportDir;
  */
 class Module implements ModuleDefinitionInterface
 {
-    public function registerAutoloaders(?DiInterface $di = null)
+    public function registerAutoloaders(DiInterface | Collection | null $container = null): void
     {
     }
 
-    public function registerServices(DiInterface $di)
+    public function registerServices(DiInterface | Collection $container): void
     {
-        $di->set(
+        $container->set(
             'view',
             function () {
                 $view = new View();
@@ -57,6 +58,6 @@ class Module implements ModuleDefinitionInterface
         );
         $loader->register();
 
-        $di->set('loader', $loader);
+        $container->set('loader', $loader);
     }
 }

--- a/tests/support/Modules/Frontend/Module.php
+++ b/tests/support/Modules/Frontend/Module.php
@@ -13,19 +13,20 @@ declare(strict_types=1);
 
 namespace Phalcon\Tests\Support\Modules\Frontend;
 
+use Phalcon\Container\Service\Collection;
 use Phalcon\Di\DiInterface;
 use Phalcon\Mvc\ModuleDefinitionInterface;
 use Phalcon\Mvc\View;
 
 class Module implements ModuleDefinitionInterface
 {
-    public function registerAutoloaders(?DiInterface $di = null)
+    public function registerAutoloaders(DiInterface | Collection | null $container = null): void
     {
     }
 
-    public function registerServices(DiInterface $di)
+    public function registerServices(DiInterface | Collection $container): void
     {
-        $di->set(
+        $container->set(
             'view',
             function () {
                 $view = new View();

--- a/tests/unit/Application/AbstractApplicationContainerTest.php
+++ b/tests/unit/Application/AbstractApplicationContainerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Application;
+
+use Phalcon\Container\Container;
+use Phalcon\Di\Di;
+use Phalcon\Mvc\Application;
+use Phalcon\Tests\AbstractUnitTestCase;
+
+final class AbstractApplicationContainerTest extends AbstractUnitTestCase
+{
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-19
+     */
+    public function testAcceptsContainer(): void
+    {
+        $container = new Container();
+        $app       = new Application($container);
+
+        $this->assertSame($container, $app->getDI());
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-19
+     */
+    public function testAcceptsDi(): void
+    {
+        $di  = new Di();
+        $app = new Application($di);
+
+        $this->assertSame($di, $app->getDI());
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-19
+     */
+    public function testAcceptsNull(): void
+    {
+        $app = new Application();
+
+        $this->assertInstanceOf(Application::class, $app);
+    }
+}

--- a/tests/unit/Container/ContainerAutoInjectTest.php
+++ b/tests/unit/Container/ContainerAutoInjectTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ *
+ * Implementation of this file has been heavily influenced by CapsulePHP.
+ * Additionally, there are implementations from ioc-interop, which is a
+ * Composer dependency, and from service-interop and resolver-interop. The
+ * latter two are copied and re-implemented here: service-interop is not yet
+ * published on Packagist, and resolver-interop requires PHP 8.4 (this project
+ * targets PHP 8.1). Once both packages become available and compatible, the
+ * copies will be replaced with the actual Composer dependencies.
+ *
+ * @link    https://github.com/capsulephp/di
+ * @license https://github.com/capsulephp/di/blob/3.x/LICENSE.md
+ *
+ * @link    https://github.com/ioc-interop/interface
+ * @license https://github.com/ioc-interop/interface/blob/1.x/LICENSE.md
+ *
+ * @link    https://github.com/service-interop/interface
+ * @license https://github.com/service-interop/interface/blob/1.x/LICENSE.md
+ *
+ * @link    https://github.com/resolver-interop/interface/tree/1.x
+ * @license https://github.com/resolver-interop/interface/blob/1.x/LICENSE.md
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Container;
+
+use Phalcon\Container\Container;
+use Phalcon\Tests\AbstractUnitTestCase;
+use Phalcon\Tests\Unit\Container\Fake\InjectionAwareComponent;
+use stdClass;
+
+final class ContainerAutoInjectTest extends AbstractUnitTestCase
+{
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-19
+     */
+    public function testResolveCallsSetDiOnInjectionAwareInstances(): void
+    {
+        $container = new Container();
+        $container->set(InjectionAwareComponent::class, InjectionAwareComponent::class);
+
+        $component = $container->get(InjectionAwareComponent::class);
+
+        // Container must have injected itself — no Di involved
+        $this->assertSame($container, $component->getDI());
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-19
+     */
+    public function testNonInjectionAwareInstancesAreUnaffected(): void
+    {
+        $container = new Container();
+        $container->set('stdClass', stdClass::class);
+
+        // Must not throw — stdClass does not implement InjectionAwareInterface
+        $obj = $container->get('stdClass');
+        $this->assertInstanceOf(stdClass::class, $obj);
+    }
+}

--- a/tests/unit/Container/Fake/InjectionAwareComponent.php
+++ b/tests/unit/Container/Fake/InjectionAwareComponent.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Container\Fake;
+
+use Phalcon\Di\InjectionAwareInterface;
+use Phalcon\Di\Traits\InjectionAwareTrait;
+
+class InjectionAwareComponent implements InjectionAwareInterface
+{
+    use InjectionAwareTrait;
+}

--- a/tests/unit/Flash/Session/GetSessionServiceTest.php
+++ b/tests/unit/Flash/Session/GetSessionServiceTest.php
@@ -49,7 +49,8 @@ final class GetSessionServiceTest extends AbstractUnitTestCase
      */
     public function testFlashSessionGetSessionServiceReturnsService(): void
     {
-        $session = $this->container->getShared('session');
+        $session = $this->container->get('session');
+        $this->container->setShared('session', $session);
         $session->start();
 
         $flash = new Session();

--- a/tests/unit/Mvc/Micro/MicroContainerTest.php
+++ b/tests/unit/Mvc/Micro/MicroContainerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Mvc\Micro;
+
+use Phalcon\Container\Container;
+use Phalcon\Di\Di;
+use Phalcon\Mvc\Micro;
+use Phalcon\Tests\AbstractUnitTestCase;
+
+class MicroContainerTest extends AbstractUnitTestCase
+{
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-19
+     */
+    public function testAcceptsContainer(): void
+    {
+        $container = new Container();
+        $app       = new Micro($container);
+
+        $this->assertSame($container, $app->getDI());
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-19
+     */
+    public function testAcceptsDi(): void
+    {
+        $di  = new Di();
+        $app = new Micro($di);
+
+        $this->assertSame($di, $app->getDI());
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-19
+     */
+    public function testAcceptsNull(): void
+    {
+        $app = new Micro();
+
+        $this->assertInstanceOf(Micro::class, $app);
+    }
+}

--- a/tests/unit/Mvc/Model/Fake/FakeModel.php
+++ b/tests/unit/Mvc/Model/Fake/FakeModel.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Mvc\Model\Fake;
+
+use Phalcon\Mvc\Model;
+
+class FakeModel extends Model
+{
+}

--- a/tests/unit/Mvc/Model/ModelContainerTest.php
+++ b/tests/unit/Mvc/Model/ModelContainerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Mvc\Model;
+
+use Phalcon\Container\Container;
+use Phalcon\Di\Di;
+use Phalcon\Mvc\Model\Criteria;
+use Phalcon\Mvc\Model\CriteriaInterface;
+use Phalcon\Tests\AbstractUnitTestCase;
+use Phalcon\Tests\Unit\Mvc\Model\Fake\FakeModel;
+
+class ModelContainerTest extends AbstractUnitTestCase
+{
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-19
+     */
+    public function testQueryAcceptsContainer(): void
+    {
+        $container = new Container();
+
+        $criteria = FakeModel::query($container);
+
+        $this->assertInstanceOf(CriteriaInterface::class, $criteria);
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-19
+     */
+    public function testQueryAcceptsDi(): void
+    {
+        $di = new Di();
+        $di->set("Phalcon\\Mvc\\Model\\Criteria", Criteria::class);
+
+        $criteria = FakeModel::query($di);
+
+        $this->assertInstanceOf(CriteriaInterface::class, $criteria);
+    }
+}


### PR DESCRIPTION
Hello!

*  Type: new feature
*  Link to issue: #742 

**In raising this pull request, I confirm the following:**

-  [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/phalcon/blob/master/CONTRIBUTING.md)
-  [x] I have checked that another pull request for this purpose does not exist
-  [x] I wrote some tests for this PR
-  [ ] I have updated the relevant CHANGELOG
-  [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Adjusted `Container` to auto-inject self into `InjectionAwareInterface` instances on `resolve()`
Widened object types to `Container`/`Di` on arguments or return types throughout the application to cater for the new `Container`
  - Application
  - Micro
  - Modules
  - Query
  - Builder
  - Criteria
  - Transaction
  - MetaData
  - Http
  - Dispatcher
  - Flash
  - Security
  - Forms