### PR TITLE
Container EnvDefault

### DIFF
--- a/src/Container/Resolver/Lazy/EnvDefault.php
+++ b/src/Container/Resolver/Lazy/EnvDefault.php
@@ -35,57 +35,29 @@ namespace Phalcon\Container\Resolver\Lazy;
 
 use Phalcon\Container\Exception\NotFound;
 
-class Env extends Lazy
+class EnvDefault extends Env
 {
     public function __construct(
-        protected string $varname,
-        protected string|null $vartype = null
+        string $varname,
+        private mixed $defaultValue,
+        string|null $vartype = null
     ) {
+        parent::__construct($varname, $vartype);
     }
 
     /**
-     * Resolve an environment variable
+     * Resolve an environment variable, returning the default if not defined
      *
      * @param object $container
      *
      * @return mixed
-     * @throws NotFound
      */
     public function resolve(object $container): mixed
     {
-        return $this->cast($this->getEnv());
-    }
-
-    /**
-     * Cast a value to the defined type (if any)
-     *
-     * @param string $value
-     *
-     * @return mixed
-     */
-    protected function cast(string $value): mixed
-    {
-        if ($this->vartype !== null) {
-            settype($value, $this->vartype);
+        try {
+            return parent::resolve($container);
+        } catch (NotFound) {
+            return $this->defaultValue;
         }
-
-        return $value;
-    }
-
-    /**
-     * Return the env value
-     *
-     * @return string
-     * @throws NotFound
-     */
-    protected function getEnv(): string
-    {
-        $envs = array_merge($_ENV, getenv());
-
-        if (!array_key_exists($this->varname, $envs)) {
-            throw NotFound::envNotDefined($this->varname);
-        }
-
-        return $envs[$this->varname];
     }
 }

--- a/src/Container/Resolver/Lazy/LazyFactory.php
+++ b/src/Container/Resolver/Lazy/LazyFactory.php
@@ -70,6 +70,11 @@ class LazyFactory
         return new Env($name, $type);
     }
 
+    public static function envDefault(string $name, mixed $default, ?string $type = null): EnvDefault
+    {
+        return new EnvDefault($name, $default, $type);
+    }
+
     /**
      * @param string                  $function
      * @param array<array-key, mixed> $args

--- a/tests/unit/Container/Resolver/Lazy/EnvDefaultTest.php
+++ b/tests/unit/Container/Resolver/Lazy/EnvDefaultTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Container\Resolver\Lazy;
+
+use Phalcon\Container\Resolver\Lazy\EnvDefault;
+use Phalcon\Container\Resolver\Lazy\LazyFactory;
+use Phalcon\Tests\AbstractUnitTestCase;
+use stdClass;
+
+final class EnvDefaultTest extends AbstractUnitTestCase
+{
+    private function makeContainer(): object
+    {
+        return new class () {
+            public function get(string $id): mixed
+            {
+                return new stdClass();
+            }
+
+            public function new(string $id): mixed
+            {
+                return new stdClass();
+            }
+        };
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        unset($_ENV['PHALCON_TEST_VAR']);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        unset($_ENV['PHALCON_TEST_VAR']);
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-19
+     */
+    public function testContainerResolverLazyEnvDefaultResolveReturnsDefaultWhenNotDefined(): void
+    {
+        $container = $this->makeContainer();
+        $lazy      = new EnvDefault('PHALCON_TEST_VAR', 'fallback');
+
+        $this->assertSame('fallback', $lazy->resolve($container));
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-19
+     */
+    public function testContainerResolverLazyEnvDefaultResolveReturnsDefaultIntWhenNotDefined(): void
+    {
+        $container = $this->makeContainer();
+        $lazy      = new EnvDefault('PHALCON_TEST_VAR', 3306);
+
+        $this->assertSame(3306, $lazy->resolve($container));
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-19
+     */
+    public function testContainerResolverLazyEnvDefaultResolveReturnsDefaultNullWhenNotDefined(): void
+    {
+        $container = $this->makeContainer();
+        $lazy      = new EnvDefault('PHALCON_TEST_VAR', null);
+
+        $this->assertNull($lazy->resolve($container));
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-19
+     */
+    public function testContainerResolverLazyEnvDefaultResolveReturnsEnvValueWhenDefined(): void
+    {
+        $_ENV['PHALCON_TEST_VAR'] = 'hello';
+        $container                = $this->makeContainer();
+        $lazy                     = new EnvDefault('PHALCON_TEST_VAR', 'fallback');
+
+        $this->assertSame('hello', $lazy->resolve($container));
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-19
+     */
+    public function testContainerResolverLazyEnvDefaultResolveCastsEnvValueWhenDefined(): void
+    {
+        $_ENV['PHALCON_TEST_VAR'] = '42';
+        $container                = $this->makeContainer();
+        $lazy                     = new EnvDefault('PHALCON_TEST_VAR', 0, 'int');
+
+        $this->assertSame(42, $lazy->resolve($container));
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-19
+     */
+    public function testContainerResolverLazyEnvDefaultDefaultIsNotCastWhenNotDefined(): void
+    {
+        $container = $this->makeContainer();
+        $lazy      = new EnvDefault('PHALCON_TEST_VAR', 99, 'string');
+
+        // Default is returned as-is — type casting only applies to the env value
+        $this->assertSame(99, $lazy->resolve($container));
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-19
+     */
+    public function testContainerResolverLazyEnvDefaultFactoryCreatesInstance(): void
+    {
+        $container = $this->makeContainer();
+        $lazy      = LazyFactory::envDefault('PHALCON_TEST_VAR', 'fallback');
+
+        $this->assertInstanceOf(EnvDefault::class, $lazy);
+        $this->assertSame('fallback', $lazy->resolve($container));
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-19
+     */
+    public function testContainerResolverLazyEnvDefaultFactoryWithTypeCreatesInstance(): void
+    {
+        $_ENV['PHALCON_TEST_VAR'] = '1';
+        $container                = $this->makeContainer();
+        $lazy                     = LazyFactory::envDefault('PHALCON_TEST_VAR', false, 'bool');
+
+        $this->assertSame(true, $lazy->resolve($container));
+    }
+}


### PR DESCRIPTION
Adding `EnvDefault` in the lazy container resolvers to allow for a default value to be available when an env variable does not exist.